### PR TITLE
feat: repo scaffold & Streamlit wrapper skeleton

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[theme]
+base = "dark"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Styx
+
+Styx retro territory game — a faithful HTML5/Canvas recreation of the classic arcade game, wrapped in Streamlit.
+
+## Run
+
+```bash
+pip install -r requirements.txt
+streamlit run app.py
+```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,12 @@
+"""Styx retro territory game - Streamlit wrapper."""
+import os
+import streamlit as st
+
+st.set_page_config(layout="wide", page_title="Styx")
+
+# Read the game HTML and embed it
+_dir = os.path.dirname(os.path.abspath(__file__))
+with open(os.path.join(_dir, "game", "index.html"), "r") as f:
+    html_content = f.read()
+
+st.components.v1.html(html_content, height=620, scrolling=False)

--- a/game/audio.js
+++ b/game/audio.js
@@ -1,0 +1,1 @@
+// TODO: implement — audio (sound effects and music)

--- a/game/enemies.js
+++ b/game/enemies.js
@@ -1,0 +1,1 @@
+// TODO: implement — Styx enemy AI and movement

--- a/game/engine.js
+++ b/game/engine.js
@@ -1,0 +1,1 @@
+// TODO: implement — core game engine (canvas setup, game loop, player, territory)

--- a/game/index.html
+++ b/game/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Styx</title>
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body {
+      background: #000;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+      overflow: hidden;
+    }
+    #styx-canvas {
+      display: block;
+      background: #000;
+      border: 2px solid #555;
+    }
+  </style>
+</head>
+<body>
+  <canvas id="styx-canvas" width="800" height="580"></canvas>
+  <script src="engine.js"></script>
+</body>
+</html>

--- a/game/scoring.js
+++ b/game/scoring.js
@@ -1,0 +1,1 @@
+// TODO: implement — scoring, level progression, high scores

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+streamlit


### PR DESCRIPTION
## Summary
Sets up the full repository structure for the Styx retro territory game.

## Changes
- `app.py` — Streamlit wrapper that reads and renders `game/index.html` via `st.components.v1.html()`
- `game/index.html` — minimal HTML5 page with `<canvas id="styx-canvas">` (800×580, black background)
- `game/engine.js`, `enemies.js`, `scoring.js`, `audio.js` — stub files
- `requirements.txt` — `streamlit` only
- `.streamlit/config.toml` — dark theme
- `README.md` — project description and run instructions

## Acceptance Criteria
- [x] All files exist at correct paths
- [x] `app.py` reads the HTML file from disk and passes to `st.components.v1.html()`
- [x] `.streamlit/config.toml` sets dark theme
- [x] All stub JS files exist

Closes #1