### PR TITLE
feat: Canvas setup, CGA palette & CI workflow (closes #2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  lint:
+    name: Syntax & Lint Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install streamlit
+
+      - name: Check Python syntax (app.py)
+        run: python -m py_compile app.py && echo "app.py OK"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Check JavaScript syntax
+        run: |
+          for f in game/*.js; do
+            node --check "$f" && echo "$f OK"
+          done

--- a/app.py
+++ b/app.py
@@ -1,12 +1,36 @@
 """Styx retro territory game - Streamlit wrapper."""
 import os
+import re
 import streamlit as st
 
 st.set_page_config(layout="wide", page_title="Styx")
 
-# Read the game HTML and embed it
 _dir = os.path.dirname(os.path.abspath(__file__))
-with open(os.path.join(_dir, "game", "index.html"), "r") as f:
+_game_dir = os.path.join(_dir, "game")
+
+# Read the game HTML
+with open(os.path.join(_game_dir, "index.html"), "r") as f:
     html_content = f.read()
+
+
+def _inline_scripts(html: str, game_dir: str) -> str:
+    """Replace <script src="foo.js"> tags with inline <script> blocks.
+
+    Streamlit components run in sandboxed iframes and may not resolve
+    relative script paths, so we inline all local JS files.
+    """
+    def replacer(match: re.Match) -> str:
+        src = match.group(1)
+        js_path = os.path.join(game_dir, src)
+        if os.path.isfile(js_path):
+            with open(js_path, "r") as fh:
+                js_src = fh.read()
+            return f"<script>\n{js_src}\n</script>"
+        return match.group(0)  # leave unknown src tags untouched
+
+    return re.sub(r'<script\s+src="([^"]+)"\s*></script>', replacer, html)
+
+
+html_content = _inline_scripts(html_content, _game_dir)
 
 st.components.v1.html(html_content, height=620, scrolling=False)

--- a/game/engine.js
+++ b/game/engine.js
@@ -1,1 +1,53 @@
-// TODO: implement — core game engine (canvas setup, game loop, player, territory)
+/**
+ * engine.js — Styx core game engine
+ * Canvas setup, 60fps game loop, CGA palette constants
+ */
+
+// CGA palette constants — all colour references must use these
+const CGA = {
+  BLACK:   '#000000',
+  CYAN:    '#00FFFF',
+  MAGENTA: '#FF00FF',
+  WHITE:   '#FFFFFF',
+};
+
+// ---------------------------------------------------------------------------
+// Canvas initialisation
+// ---------------------------------------------------------------------------
+const canvas = document.getElementById('styx-canvas');
+const ctx    = canvas.getContext('2d');
+
+const CANVAS_W = canvas.width;   // 800
+const CANVAS_H = canvas.height;  // 580
+
+// Playfield border inset (pixels from canvas edge)
+const BORDER_INSET = 8;
+
+// ---------------------------------------------------------------------------
+// Game loop
+// ---------------------------------------------------------------------------
+function render() {
+  // Clear with black background
+  ctx.fillStyle = CGA.BLACK;
+  ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+
+  // White playfield border rectangle
+  ctx.strokeStyle = CGA.WHITE;
+  ctx.lineWidth   = 2;
+  ctx.strokeRect(
+    BORDER_INSET,
+    BORDER_INSET,
+    CANVAS_W - BORDER_INSET * 2,
+    CANVAS_H - BORDER_INSET * 2
+  );
+}
+
+function gameLoop() {
+  render();
+  requestAnimationFrame(gameLoop);
+}
+
+// Kick off the loop once the page is ready
+window.addEventListener('load', function () {
+  requestAnimationFrame(gameLoop);
+});


### PR DESCRIPTION
## Summary

Implements Issue #2 (Canvas setup & CGA palette) and adds the CI workflow requested by the reviewer.

### Changes

**`game/engine.js`** (was a TODO stub)
- `CGA` palette constants: `BLACK`, `CYAN`, `MAGENTA`, `WHITE`
- Canvas setup: grabs `#styx-canvas` (800×580), gets 2D context
- 60fps `requestAnimationFrame` game loop
- Each frame: fills canvas with `CGA.BLACK`, strokes white border rect (8px inset) with `CGA.WHITE`
- No hardcoded colour strings — all colours via CGA constants

**`app.py`**
- Added `_inline_scripts()` helper that replaces `<script src="foo.js">` with inline `<script>` blocks
- Ensures JS executes correctly inside Streamlit's sandboxed iframe

**`.github/workflows/ci.yml`** (new)
- Triggers on push and pull_request for all branches
- Steps: checkout → Python 3.11 → install streamlit → `py_compile app.py` → Node 20 → `node --check` all `game/*.js`
- Lightweight, fast CI gate

## Acceptance Criteria
- [x] CGA constants defined and used; no raw colour strings elsewhere
- [x] Canvas fills black each frame
- [x] White border rectangle rendered each frame
- [x] `requestAnimationFrame` loop at 60fps
- [x] CI workflow file present and syntactically valid

Closes #2