### PR TITLE
feat: flood-fill territory claiming & HUD percentage (closes #5)

### DIFF
--- a/game/engine.js
+++ b/game/engine.js
@@ -1,7 +1,8 @@
 /**
  * engine.js — Styx core game engine
  * Canvas setup, 60fps game loop, CGA palette constants,
- * player movement (issue #3), draw mode & Stix line rendering (issue #4).
+ * player movement (issue #3), draw mode & Stix line rendering (issue #4),
+ * flood-fill territory claiming & HUD (issue #5).
  */
 
 // CGA palette constants — all colour references must use these
@@ -33,6 +34,16 @@ const FIELD_TOP    = BORDER_INSET;
 const FIELD_RIGHT  = CANVAS_W - BORDER_INSET;
 const FIELD_BOTTOM = CANVAS_H - BORDER_INSET;
 
+// Grid dimensions (number of CELL-sized slots across the playfield including border)
+const FIELD_W_CELLS = (FIELD_RIGHT - FIELD_LEFT) / CELL;
+const FIELD_H_CELLS = (FIELD_BOTTOM - FIELD_TOP) / CELL;
+
+/**
+ * Total interior (non-border) cells — used for percentage calculation.
+ * Subtract 2 on each axis to exclude the 1-cell-wide border row/column.
+ */
+const TOTAL_PLAYFIELD_CELLS = (FIELD_W_CELLS - 2) * (FIELD_H_CELLS - 2);
+
 // ---------------------------------------------------------------------------
 // Player state
 // ---------------------------------------------------------------------------
@@ -53,13 +64,18 @@ const keysHeld = new Set();
 /**
  * Current in-progress Stix draw line.
  * Array of {x, y} pixel positions tracing the path the player has drawn.
- * Populated while SPACEBAR is held and player moves.
- * Cleared when line completes (connects back to border) or SPACEBAR released.
  */
 let currentLine = [];
 
 /** True when SPACEBAR is held and player is in draw mode. */
 let drawMode = false;
+
+/**
+ * Claimed territory cells.
+ * Set of "cx,cy" grid-coordinate keys (not pixel coords).
+ * cx/cy are cell indices relative to FIELD_LEFT/FIELD_TOP.
+ */
+const claimedCells = new Set();
 
 // ---------------------------------------------------------------------------
 // Helper: snap a pixel value to the nearest CELL grid position
@@ -79,6 +95,24 @@ function clampToField(px, py) {
 }
 
 // ---------------------------------------------------------------------------
+// Helper: convert pixel position to grid cell coordinates
+// ---------------------------------------------------------------------------
+function pixelToCell(px, py) {
+  return {
+    cx: Math.round((px - FIELD_LEFT) / CELL),
+    cy: Math.round((py - FIELD_TOP)  / CELL),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: cell key from pixel position
+// ---------------------------------------------------------------------------
+function cellKey(px, py) {
+  const { cx, cy } = pixelToCell(px, py);
+  return `${cx},${cy}`;
+}
+
+// ---------------------------------------------------------------------------
 // Helper: is (px, py) on the outer border perimeter?
 // ---------------------------------------------------------------------------
 function isOnOuterBorder(px, py) {
@@ -95,22 +129,151 @@ function isOnOuterBorder(px, py) {
 }
 
 // ---------------------------------------------------------------------------
-// Helper: is (px, py) on a valid position for normal (non-draw) movement?
-// Extended in issue #5 to include claimed territory edges.
+// Helper: is (px, py) on the edge of claimed territory?
+// A claimed cell is an "edge" if at least one of its 4 cardinal neighbours
+// is an unclaimed interior cell.
 // ---------------------------------------------------------------------------
-function isOnSafeEdge(px, py) {
-  return isOnOuterBorder(px, py);
+function isOnClaimedEdge(px, py) {
+  const k = cellKey(px, py);
+  if (!claimedCells.has(k)) return false;
+  const { cx, cy } = pixelToCell(px, py);
+  const neighbours = [
+    `${cx-1},${cy}`, `${cx+1},${cy}`,
+    `${cx},${cy-1}`, `${cx},${cy+1}`,
+  ];
+  return neighbours.some(nk => !claimedCells.has(nk));
 }
 
 // ---------------------------------------------------------------------------
-// Stub: flood-fill claim — implemented in issue #5.
-// Called when the draw line connects back to a safe edge.
-//
-// @param {Array<{x:number, y:number}>} borderLine - Completed Stix line cells
-// @param {{x:number, y:number}|null} enemyPosition - See issue #5 for details
+// Helper: is (px, py) a valid position for normal (non-draw) movement?
+// Includes outer border and edges of claimed territory.
 // ---------------------------------------------------------------------------
-function floodFillClaim(borderLine, enemyPosition = null) { // eslint-disable-line no-unused-vars
-  // TODO: implement in issue #5 (flood-fill territory claiming)
+function isOnSafeEdge(px, py) {
+  return isOnOuterBorder(px, py) || isOnClaimedEdge(px, py);
+}
+
+// ---------------------------------------------------------------------------
+// Flood-fill territory claiming
+//
+// @param {Array<{x:number, y:number}>} borderLine
+//   The newly completed Stix border line (pixel positions of drawn cells).
+//   These cells form the new border between claimed and unclaimed territory.
+//
+// @param {{x:number, y:number}|null} enemyPosition
+//   Optional enemy position in pixel coordinates.
+//
+//   PHASE 1 (no enemies): pass null — the function fills the SMALLER of the
+//   two regions enclosed by the new border line + existing claimed territory.
+//   Smaller-region fill is the authentic Styx mechanic (maximises risk/reward).
+//
+//   PHASE 2 (enemies): pass the enemy's current {x, y}.
+//   The function fills the region that does NOT contain the enemy, ensuring
+//   the enemy is never trapped in claimed territory. If the enemy is on a
+//   barrier cell (already claimed), all enclosed regions are safe to fill.
+//   If multiple safe regions exist, the largest is chosen to reward the player.
+//
+//   Example Phase 2 call:
+//     floodFillClaim(completedLine, { x: enemy.x, y: enemy.y });
+// ---------------------------------------------------------------------------
+function floodFillClaim(borderLine, enemyPosition = null) {
+  // 1. Add borderLine pixels to claimedCells (they become the new wall)
+  borderLine.forEach(({ x, y }) => {
+    claimedCells.add(cellKey(x, y));
+  });
+
+  // 2. Build barrier set: outer border rows/cols + all claimed cells
+  //    Barrier = cannot be filled; flood-fill stays inside barriers.
+  const barriers = new Set(claimedCells);
+  for (let cx = 0; cx < FIELD_W_CELLS; cx++) {
+    barriers.add(`${cx},0`);
+    barriers.add(`${cx},${FIELD_H_CELLS - 1}`);
+  }
+  for (let cy = 0; cy < FIELD_H_CELLS; cy++) {
+    barriers.add(`0,${cy}`);
+    barriers.add(`${FIELD_W_CELLS - 1},${cy}`);
+  }
+
+  // 3. Flood-fill all distinct interior regions (BFS per unvisited seed)
+  const visited = new Set();
+  const regions = [];
+
+  function bfs(startCx, startCy) {
+    const region = new Set();
+    const queue = [[startCx, startCy]];
+    const startKey = `${startCx},${startCy}`;
+    visited.add(startKey);
+    region.add(startKey);
+    while (queue.length > 0) {
+      const [cx, cy] = queue.shift();
+      for (const [nx, ny] of [[cx-1,cy],[cx+1,cy],[cx,cy-1],[cx,cy+1]]) {
+        const nk = `${nx},${ny}`;
+        if (!visited.has(nk) && !barriers.has(nk) &&
+            nx >= 1 && nx < FIELD_W_CELLS - 1 &&
+            ny >= 1 && ny < FIELD_H_CELLS - 1) {
+          visited.add(nk);
+          region.add(nk);
+          queue.push([nx, ny]);
+        }
+      }
+    }
+    return region;
+  }
+
+  for (let cx = 1; cx < FIELD_W_CELLS - 1; cx++) {
+    for (let cy = 1; cy < FIELD_H_CELLS - 1; cy++) {
+      const k = `${cx},${cy}`;
+      if (!visited.has(k) && !barriers.has(k)) {
+        regions.push(bfs(cx, cy));
+      }
+    }
+  }
+
+  if (regions.length === 0) {
+    checkLevelComplete();
+    return;
+  }
+
+  // 4. Choose which region to fill
+  let regionToFill;
+
+  if (enemyPosition !== null) {
+    // Phase 2: avoid the region containing the enemy
+    const ek = cellKey(enemyPosition.x, enemyPosition.y);
+    const enemyRegionIdx = regions.findIndex(r => r.has(ek));
+
+    if (enemyRegionIdx === -1) {
+      // Enemy is on a barrier — all regions are safe; pick the largest
+      regionToFill = regions.reduce((a, b) => a.size >= b.size ? a : b);
+    } else {
+      // Filter out the enemy's region; pick the largest remaining safe region
+      const safeRegions = regions.filter((_, i) => i !== enemyRegionIdx);
+      if (safeRegions.length === 0) {
+        checkLevelComplete();
+        return;
+      }
+      regionToFill = safeRegions.reduce((a, b) => a.size >= b.size ? a : b);
+    }
+  } else {
+    // Phase 1: fill the smaller region (authentic Styx behaviour)
+    regionToFill = regions.reduce((a, b) => a.size <= b.size ? a : b);
+  }
+
+  // 5. Claim the chosen region
+  regionToFill.forEach(k => claimedCells.add(k));
+
+  checkLevelComplete();
+}
+
+// ---------------------------------------------------------------------------
+// Check and dispatch level-complete event
+// ---------------------------------------------------------------------------
+function checkLevelComplete() {
+  const percentage = (claimedCells.size / TOTAL_PLAYFIELD_CELLS) * 100;
+  if (percentage >= 80) {
+    window.dispatchEvent(new CustomEvent('level-complete', {
+      detail: { percentage: percentage.toFixed(1) },
+    }));
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -124,7 +287,7 @@ window.addEventListener('keydown', function (e) {
     e.preventDefault();
   }
 
-  // SPACEBAR toggles draw mode on
+  // SPACEBAR activates draw mode
   if (e.code === 'Space') {
     if (!drawMode) {
       drawMode = true;
@@ -155,7 +318,7 @@ window.addEventListener('keydown', function (e) {
 
     // Check if moving back onto a safe edge while we have a line in progress
     if (currentLine.length > 0 && isOnSafeEdge(newPos.x, newPos.y)) {
-      // Line complete — add terminal point, trigger flood-fill, reset draw state
+      // Line complete — trigger flood-fill and reset draw state
       currentLine.push({ x: newPos.x, y: newPos.y });
       player.x = newPos.x;
       player.y = newPos.y;
@@ -164,7 +327,7 @@ window.addEventListener('keydown', function (e) {
       drawMode = false;
       floodFillClaim(completedLine, null);
     } else {
-      // Extend the line: record current player position before moving
+      // Extend the line: record current position before moving
       currentLine.push({ x: player.x, y: player.y });
       player.x = newPos.x;
       player.y = newPos.y;
@@ -184,13 +347,12 @@ window.addEventListener('keyup', function (e) {
   if (e.code === 'Space') {
     if (drawMode) {
       if (currentLine.length > 0) {
-        // SPACEBAR released mid-draw: erase unfinished line, return player to border
+        // SPACEBAR released mid-draw: erase line, snap player to nearest border
         currentLine = [];
-        // Snap player to nearest border edge
         const px = snapToGrid(player.x);
         const py = snapToGrid(player.y);
 
-        // Project to nearest border side
+        // Project to nearest border side by Manhattan distance
         const distLeft   = px - FIELD_LEFT;
         const distRight  = (FIELD_RIGHT - CELL) - px;
         const distTop    = py - FIELD_TOP;
@@ -199,12 +361,11 @@ window.addEventListener('keyup', function (e) {
 
         let bx = px;
         let by = py;
-        if (minDist === distLeft)   bx = FIELD_LEFT;
+        if      (minDist === distLeft)   bx = FIELD_LEFT;
         else if (minDist === distRight)  bx = FIELD_RIGHT - CELL;
         else if (minDist === distTop)    by = FIELD_TOP;
-        else                              by = FIELD_BOTTOM - CELL;
+        else                             by = FIELD_BOTTOM - CELL;
 
-        // Clamp to valid range after projection
         const clamped = clampToField(bx, by);
         player.x = clamped.x;
         player.y = clamped.y;
@@ -217,6 +378,19 @@ window.addEventListener('keyup', function (e) {
 // ---------------------------------------------------------------------------
 // Rendering
 // ---------------------------------------------------------------------------
+
+/**
+ * Draw all claimed territory cells as cyan 8×8 squares.
+ */
+function renderClaimedTerritory() {
+  ctx.fillStyle = CGA.CYAN;
+  claimedCells.forEach(k => {
+    const [cx, cy] = k.split(',').map(Number);
+    const px = FIELD_LEFT + cx * CELL;
+    const py = FIELD_TOP  + cy * CELL;
+    ctx.fillRect(px, py, CELL, CELL);
+  });
+}
 
 /**
  * Draw the in-progress Stix line as white filled squares (one per cell).
@@ -237,10 +411,23 @@ function renderPlayer() {
   ctx.fillRect(player.x, player.y, CELL, CELL);
 }
 
+/**
+ * Draw the territory percentage HUD (white monospace text, top of canvas).
+ */
+function renderHUD() {
+  const percentage = ((claimedCells.size / TOTAL_PLAYFIELD_CELLS) * 100).toFixed(1);
+  ctx.fillStyle = CGA.WHITE;
+  ctx.font = 'bold 13px monospace';
+  ctx.fillText(`Territory: ${percentage}%`, FIELD_LEFT + 4, FIELD_TOP - 2);
+}
+
 function render() {
   // Clear with black background
   ctx.fillStyle = CGA.BLACK;
   ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+
+  // Claimed territory (below the border line)
+  renderClaimedTerritory();
 
   // White playfield border rectangle
   ctx.strokeStyle = CGA.WHITE;
@@ -252,11 +439,14 @@ function render() {
     CANVAS_H - BORDER_INSET * 2
   );
 
-  // In-progress draw line (drawn before player so player is on top)
+  // In-progress draw line (beneath player)
   renderCurrentLine();
 
-  // Player
+  // Player (on top)
   renderPlayer();
+
+  // HUD overlay
+  renderHUD();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements issue #5 — flood-fill territory claiming with HUD percentage display.

Depends on #4 (draw mode). Stacks on `feature/issue-4-draw-mode`.

## Changes

### Territory State
- `claimedCells` — `Set<string>` of `"cx,cy"` grid keys tracking all claimed territory
- `TOTAL_PLAYFIELD_CELLS` — correct count of interior (non-border) cells for % calculation

### `floodFillClaim(borderLine, enemyPosition = null)`
Full BFS flood-fill implementation:
1. Adds `borderLine` cells to `claimedCells` as the new wall
2. Builds barrier set (outer border rows/cols + all claimed cells)
3. BFS enumerates all distinct interior regions
4. **Phase 1** (`enemyPosition = null`): fills the **smaller** region — authentic Styx mechanic
5. **Phase 2** (`enemyPosition` provided): fills the largest region **not containing the enemy** — fully documented with JSDoc for Phase 2 implementors

### `isOnClaimedEdge(px, py)`
Extends `isOnSafeEdge()` — player can walk on the edges of claimed territory as well as the outer border.

### `checkLevelComplete()`
Dispatches a `level-complete` `CustomEvent` on `window` when claimed territory ≥ 80%.

### `renderClaimedTerritory()`
Draws all claimed cells as cyan 8×8 squares each frame.

### `renderHUD()`
Overlays territory percentage as white monospace text at top of canvas.

## Acceptance Criteria Checklist

- [x] Drawing a closed shape and returning to border triggers flood-fill
- [x] Enclosed area fills with cyan
- [x] Percentage HUD updates correctly after each claim
- [x] Multiple claims accumulate correctly
- [x] Smaller area selected when `enemyPosition` is null (Phase 1)
- [x] Canvas re-renders showing all accumulated claimed territory
- [x] `level-complete` event fires when claimed territory ≥ 80%
- [x] `floodFillClaim` accepts optional `enemyPosition` parameter (documented)
- [x] When `enemyPosition` provided, filled region does NOT contain the enemy

Closes #5