### PR TITLE
feat: Styx field enemy (closes #11)

### DIFF
--- a/game/enemies.js
+++ b/game/enemies.js
@@ -1,1 +1,221 @@
-// TODO: implement — Styx enemy AI and movement
+/**
+ * enemies.js — Styx enemy AI
+ *
+ * Exports:
+ *   styxEnemies      — array of active Styx enemy objects
+ *   initStyxEnemies  — called on game start / level reset
+ *   updateStyxEnemies(dt, claimedCells, currentLine, player, onDeath)
+ *   renderStyxEnemies(ctx)
+ */
+
+/* ---- Constants (must match engine.js) ------------------------------------ */
+const ENEMY_CELL   = 8;
+const ENEMY_FIELD_LEFT   = 8;
+const ENEMY_FIELD_TOP    = 8;
+const ENEMY_FIELD_RIGHT  = 800 - 8;   // CANVAS_W - BORDER_INSET
+const ENEMY_FIELD_BOTTOM = 580 - 8;   // CANVAS_H - BORDER_INSET
+
+const STYX_SPEED = 48;   // pixels per second
+const STYX_COLORS = ['#00FFFF', '#FF00FF', '#FFFFFF'];   // CGA cycle
+
+/* ---- Helpers ------------------------------------------------------------- */
+function snapCell(v) {
+  return Math.round(v / ENEMY_CELL) * ENEMY_CELL;
+}
+
+function cellKeyE(px, py) {
+  const cx = Math.round((px - ENEMY_FIELD_LEFT) / ENEMY_CELL);
+  const cy = Math.round((py - ENEMY_FIELD_TOP)  / ENEMY_CELL);
+  return `${cx},${cy}`;
+}
+
+function isClaimed(px, py, claimedCells) {
+  return claimedCells.has(cellKeyE(px, py));
+}
+
+function isOuterBorder(px, py) {
+  const x = snapCell(px);
+  const y = snapCell(py);
+  const inH = x >= ENEMY_FIELD_LEFT && x <= ENEMY_FIELD_RIGHT - ENEMY_CELL;
+  const inV = y >= ENEMY_FIELD_TOP  && y <= ENEMY_FIELD_BOTTOM - ENEMY_CELL;
+  return ((x === ENEMY_FIELD_LEFT || x === ENEMY_FIELD_RIGHT - ENEMY_CELL) && inV) ||
+         ((y === ENEMY_FIELD_TOP  || y === ENEMY_FIELD_BOTTOM - ENEMY_CELL) && inH);
+}
+
+/** Returns a random axis-aligned unit-cell direction {dx, dy} */
+function randomDir() {
+  const dirs = [
+    { dx:  ENEMY_CELL, dy: 0 },
+    { dx: -ENEMY_CELL, dy: 0 },
+    { dx: 0, dy:  ENEMY_CELL },
+    { dx: 0, dy: -ENEMY_CELL },
+  ];
+  return dirs[Math.floor(Math.random() * dirs.length)];
+}
+
+/** Clamp to interior (not outer border) */
+function clampInterior(x, y) {
+  return {
+    x: Math.max(ENEMY_FIELD_LEFT + ENEMY_CELL,
+                Math.min(ENEMY_FIELD_RIGHT  - ENEMY_CELL * 2, snapCell(x))),
+    y: Math.max(ENEMY_FIELD_TOP  + ENEMY_CELL,
+                Math.min(ENEMY_FIELD_BOTTOM - ENEMY_CELL * 2, snapCell(y))),
+  };
+}
+
+/** Pick a random unclaimed interior start position */
+function randomInteriorPos(claimedCells) {
+  const maxTries = 200;
+  for (let i = 0; i < maxTries; i++) {
+    const fwCells = (ENEMY_FIELD_RIGHT  - ENEMY_FIELD_LEFT) / ENEMY_CELL;
+    const fhCells = (ENEMY_FIELD_BOTTOM - ENEMY_FIELD_TOP)  / ENEMY_CELL;
+    const cx = 1 + Math.floor(Math.random() * (fwCells - 2));
+    const cy = 1 + Math.floor(Math.random() * (fhCells - 2));
+    const px = ENEMY_FIELD_LEFT + cx * ENEMY_CELL;
+    const py = ENEMY_FIELD_TOP  + cy * ENEMY_CELL;
+    if (!isClaimed(px, py, claimedCells) && !isOuterBorder(px, py)) {
+      return { x: px, y: py };
+    }
+  }
+  // Fallback: near-centre
+  return clampInterior(
+    ENEMY_FIELD_LEFT + (ENEMY_FIELD_RIGHT  - ENEMY_FIELD_LEFT) / 2,
+    ENEMY_FIELD_TOP  + (ENEMY_FIELD_BOTTOM - ENEMY_FIELD_TOP)  / 2,
+  );
+}
+
+/* ---- Styx enemy object --------------------------------------------------- */
+
+function createStyx(claimedCells) {
+  const pos = randomInteriorPos(claimedCells);
+  const dir = randomDir();
+  return {
+    x: pos.x,
+    y: pos.y,
+    // sub-pixel accumulator for smooth movement
+    acc: 0,
+    dx: dir.dx,
+    dy: dir.dy,
+    // visual: 3–5 line segments per Styx
+    numSegments: 3 + Math.floor(Math.random() * 3),
+    // angle offset for animation
+    angle: Math.random() * Math.PI * 2,
+    colorIdx: Math.floor(Math.random() * STYX_COLORS.length),
+    colorTimer: 0,
+  };
+}
+
+/* ---- Module state -------------------------------------------------------- */
+const styxEnemies = [];
+
+function initStyxEnemies(level, claimedCells) {
+  styxEnemies.length = 0;
+  const count = Math.min(1 + (level - 1), 3);
+  for (let i = 0; i < count; i++) {
+    styxEnemies.push(createStyx(claimedCells));
+  }
+}
+
+/**
+ * Move a single Styx one cell in its current direction.
+ * If the destination is a claimed cell, outer border, or out of bounds,
+ * pick a new random direction and try again (up to 4 tries).
+ */
+function moveStyxOneCell(styx, claimedCells) {
+  const dirs = [
+    { dx: styx.dx, dy: styx.dy },
+    ...([
+      { dx: ENEMY_CELL, dy: 0 }, { dx: -ENEMY_CELL, dy: 0 },
+      { dx: 0, dy: ENEMY_CELL }, { dx: 0, dy: -ENEMY_CELL },
+    ].filter(d => d.dx !== styx.dx || d.dy !== styx.dy)
+      .sort(() => Math.random() - 0.5)),
+  ];
+
+  for (const d of dirs) {
+    const nx = styx.x + d.dx;
+    const ny = styx.y + d.dy;
+    const inBounds =
+      nx >= ENEMY_FIELD_LEFT + ENEMY_CELL &&
+      nx <= ENEMY_FIELD_RIGHT - ENEMY_CELL * 2 &&
+      ny >= ENEMY_FIELD_TOP  + ENEMY_CELL &&
+      ny <= ENEMY_FIELD_BOTTOM - ENEMY_CELL * 2;
+    if (inBounds && !isClaimed(nx, ny, claimedCells) && !isOuterBorder(nx, ny)) {
+      styx.x  = nx;
+      styx.y  = ny;
+      styx.dx = d.dx;
+      styx.dy = d.dy;
+      return;
+    }
+  }
+  // Completely boxed in — stay put and pick new random dir
+  const d = randomDir();
+  styx.dx = d.dx;
+  styx.dy = d.dy;
+}
+
+/**
+ * Update all Styx enemies.
+ *
+ * @param {number} dt             - Delta time in seconds
+ * @param {Set<string>} claimedCells - Claimed cell keys from engine
+ * @param {Array<{x,y}>} currentLine - Player's in-progress draw line
+ * @param {{x,y}} player         - Player position
+ * @param {function} onDeath     - Callback: called when Styx hits in-progress line
+ */
+function updateStyxEnemies(dt, claimedCells, currentLine, player, onDeath) {
+  for (const styx of styxEnemies) {
+    // Advance animation angle
+    styx.angle += dt * 3.5;
+
+    // Color cycling
+    styx.colorTimer += dt;
+    if (styx.colorTimer > 0.12) {
+      styx.colorTimer = 0;
+      styx.colorIdx = (styx.colorIdx + 1) % STYX_COLORS.length;
+    }
+
+    // Movement (cell-based with sub-pixel accumulation for smooth pacing)
+    styx.acc += STYX_SPEED * dt;
+    while (styx.acc >= ENEMY_CELL) {
+      styx.acc -= ENEMY_CELL;
+      moveStyxOneCell(styx, claimedCells);
+    }
+
+    // Collision: does Styx overlap any cell of the in-progress draw line?
+    if (currentLine.length > 0) {
+      const hit = currentLine.some(
+        p => Math.abs(p.x - styx.x) < ENEMY_CELL && Math.abs(p.y - styx.y) < ENEMY_CELL
+      );
+      if (hit) {
+        onDeath();
+      }
+    }
+  }
+}
+
+/**
+ * Render all Styx enemies as animated bundles of intersecting lines.
+ * @param {CanvasRenderingContext2D} ctx
+ */
+function renderStyxEnemies(ctx) {
+  for (const styx of styxEnemies) {
+    const cx = styx.x + ENEMY_CELL / 2;
+    const cy = styx.y + ENEMY_CELL / 2;
+    const len = ENEMY_CELL * 1.2;
+
+    ctx.save();
+    ctx.lineWidth = 1.5;
+
+    for (let i = 0; i < styx.numSegments; i++) {
+      const theta = styx.angle + (i * Math.PI) / styx.numSegments;
+      const color = STYX_COLORS[(styx.colorIdx + i) % STYX_COLORS.length];
+      ctx.strokeStyle = color;
+      ctx.beginPath();
+      ctx.moveTo(cx + Math.cos(theta) * len,       cy + Math.sin(theta) * len);
+      ctx.lineTo(cx + Math.cos(theta + Math.PI) * len, cy + Math.sin(theta + Math.PI) * len);
+      ctx.stroke();
+    }
+
+    ctx.restore();
+  }
+}

--- a/game/engine.js
+++ b/game/engine.js
@@ -2,7 +2,8 @@
  * engine.js — Styx core game engine
  * Canvas setup, 60fps game loop, CGA palette constants,
  * player movement (issue #3), draw mode & Stix line rendering (issue #4),
- * flood-fill territory claiming & HUD (issue #5).
+ * flood-fill territory claiming & HUD (issue #5),
+ * Styx field enemy (issue #11).
  */
 
 // CGA palette constants — all colour references must use these
@@ -43,6 +44,14 @@ const FIELD_H_CELLS = (FIELD_BOTTOM - FIELD_TOP) / CELL;
  * Subtract 2 on each axis to exclude the 1-cell-wide border row/column.
  */
 const TOTAL_PLAYFIELD_CELLS = (FIELD_W_CELLS - 2) * (FIELD_H_CELLS - 2);
+
+// ---------------------------------------------------------------------------
+// Game state
+// ---------------------------------------------------------------------------
+
+let lives = 3;
+let level = 1;
+let gameOver = false;
 
 // ---------------------------------------------------------------------------
 // Player state
@@ -153,27 +162,26 @@ function isOnSafeEdge(px, py) {
 }
 
 // ---------------------------------------------------------------------------
+// Death & reset
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle player death: lose a life, reset draw state, snap player to border.
+ */
+function triggerDeath() {
+  lives -= 1;
+  currentLine = [];
+  drawMode = false;
+  player.x = FIELD_LEFT;
+  player.y = FIELD_TOP;
+  if (lives <= 0) {
+    gameOver = true;
+    window.dispatchEvent(new CustomEvent('game-over'));
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Flood-fill territory claiming
-//
-// @param {Array<{x:number, y:number}>} borderLine
-//   The newly completed Stix border line (pixel positions of drawn cells).
-//   These cells form the new border between claimed and unclaimed territory.
-//
-// @param {{x:number, y:number}|null} enemyPosition
-//   Optional enemy position in pixel coordinates.
-//
-//   PHASE 1 (no enemies): pass null — the function fills the SMALLER of the
-//   two regions enclosed by the new border line + existing claimed territory.
-//   Smaller-region fill is the authentic Styx mechanic (maximises risk/reward).
-//
-//   PHASE 2 (enemies): pass the enemy's current {x, y}.
-//   The function fills the region that does NOT contain the enemy, ensuring
-//   the enemy is never trapped in claimed territory. If the enemy is on a
-//   barrier cell (already claimed), all enclosed regions are safe to fill.
-//   If multiple safe regions exist, the largest is chosen to reward the player.
-//
-//   Example Phase 2 call:
-//     floodFillClaim(completedLine, { x: enemy.x, y: enemy.y });
 // ---------------------------------------------------------------------------
 function floodFillClaim(borderLine, enemyPosition = null) {
   // 1. Add borderLine pixels to claimedCells (they become the new wall)
@@ -182,7 +190,6 @@ function floodFillClaim(borderLine, enemyPosition = null) {
   });
 
   // 2. Build barrier set: outer border rows/cols + all claimed cells
-  //    Barrier = cannot be filled; flood-fill stays inside barriers.
   const barriers = new Set(claimedCells);
   for (let cx = 0; cx < FIELD_W_CELLS; cx++) {
     barriers.add(`${cx},0`);
@@ -287,6 +294,8 @@ window.addEventListener('keydown', function (e) {
     e.preventDefault();
   }
 
+  if (gameOver) return;
+
   // SPACEBAR activates draw mode
   if (e.code === 'Space') {
     if (!drawMode) {
@@ -325,7 +334,9 @@ window.addEventListener('keydown', function (e) {
       const completedLine = currentLine.slice();
       currentLine = [];
       drawMode = false;
-      floodFillClaim(completedLine, null);
+      // Pass Styx position so fill avoids trapping enemies
+      const enemyPos = styxEnemies.length > 0 ? { x: styxEnemies[0].x, y: styxEnemies[0].y } : null;
+      floodFillClaim(completedLine, enemyPos);
     } else {
       // Extend the line: record current position before moving
       currentLine.push({ x: player.x, y: player.y });
@@ -412,13 +423,28 @@ function renderPlayer() {
 }
 
 /**
- * Draw the territory percentage HUD (white monospace text, top of canvas).
+ * Draw the territory percentage and lives HUD.
  */
 function renderHUD() {
   const percentage = ((claimedCells.size / TOTAL_PLAYFIELD_CELLS) * 100).toFixed(1);
   ctx.fillStyle = CGA.WHITE;
   ctx.font = 'bold 13px monospace';
   ctx.fillText(`Territory: ${percentage}%`, FIELD_LEFT + 4, FIELD_TOP - 2);
+  ctx.fillText(`Lives: ${lives}`, FIELD_RIGHT - 80, FIELD_TOP - 2);
+  ctx.fillText(`Level: ${level}`, FIELD_LEFT + 160, FIELD_TOP - 2);
+}
+
+function renderGameOver() {
+  ctx.fillStyle = 'rgba(0,0,0,0.6)';
+  ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+  ctx.fillStyle = CGA.MAGENTA;
+  ctx.font = 'bold 32px monospace';
+  ctx.textAlign = 'center';
+  ctx.fillText('GAME OVER', CANVAS_W / 2, CANVAS_H / 2);
+  ctx.fillStyle = CGA.WHITE;
+  ctx.font = 'bold 16px monospace';
+  ctx.fillText('Refresh to play again', CANVAS_W / 2, CANVAS_H / 2 + 36);
+  ctx.textAlign = 'left';
 }
 
 function render() {
@@ -442,22 +468,39 @@ function render() {
   // In-progress draw line (beneath player)
   renderCurrentLine();
 
+  // Styx enemies
+  renderStyxEnemies(ctx);
+
   // Player (on top)
   renderPlayer();
 
   // HUD overlay
   renderHUD();
+
+  if (gameOver) {
+    renderGameOver();
+  }
 }
 
 // ---------------------------------------------------------------------------
 // Game loop
 // ---------------------------------------------------------------------------
-function gameLoop() {
+let lastTime = null;
+
+function gameLoop(timestamp) {
+  const dt = lastTime === null ? 0 : Math.min((timestamp - lastTime) / 1000, 0.1);
+  lastTime = timestamp;
+
+  if (!gameOver) {
+    updateStyxEnemies(dt, claimedCells, currentLine, player, triggerDeath);
+  }
+
   render();
   requestAnimationFrame(gameLoop);
 }
 
 // Kick off the loop once the page is ready
 window.addEventListener('load', function () {
+  initStyxEnemies(level, claimedCells);
   requestAnimationFrame(gameLoop);
 });

--- a/game/index.html
+++ b/game/index.html
@@ -23,6 +23,7 @@
 </head>
 <body>
   <canvas id="styx-canvas" width="800" height="580"></canvas>
+  <script src="enemies.js"></script>
   <script src="engine.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Implements the Styx field enemy — an animated bundle of intersecting lines that bounces around unclaimed territory.

## Changes

- **enemies.js**: New file. `Styx` class with cell-based random movement confined strictly to unclaimed interior cells. 3–5 rotating line segments cycle through CGA colors. `initStyxEnemies(level, claimedCells)`, `updateStyxEnemies(dt, claimedCells, currentLine, player, onDeath)`, `renderStyxEnemies(ctx)` exported as globals.
- **engine.js**: Integrate enemies — `initStyxEnemies` on load, `updateStyxEnemies` in delta-time game loop, `renderStyxEnemies` in render pass. Add `lives`/`level` state, `triggerDeath()` (resets draw line, snaps player to border, decrements lives). Pass Styx position to `floodFillClaim` so fill avoids trapping enemies. Game-over overlay on 0 lives.
- **index.html**: Load `enemies.js` before `engine.js`.

## Acceptance criteria covered
- [x] Animated bundle of 3–5 intersecting lines cycling CGA colors
- [x] Moves randomly in unclaimed territory; bounces off borders and claimed edges
- [x] Collision with in-progress stixLine → death (line cleared, player reset to border)
- [x] No harm when player is on border/claimed territory
- [x] Level 1: 1 Styx; Level N: min(N, 3) Styx
- [x] `enemyPosition` passed to floodFillClaim

Closes #11