### PR TITLE
feat: Level difficulty scaling (closes #15)

### DIFF
--- a/game/enemies.js
+++ b/game/enemies.js
@@ -19,7 +19,8 @@ const ENEMY_FIELD_TOP    = 8;
 const ENEMY_FIELD_RIGHT  = 800 - 8;   // CANVAS_W - BORDER_INSET
 const ENEMY_FIELD_BOTTOM = 580 - 8;   // CANVAS_H - BORDER_INSET
 
-const STYX_SPEED = 48;   // pixels per second
+const STYX_SPEED = 48;   // pixels per second (base speed at level 1)
+const STYX_SPEED_SCALE = 1.15; // speed multiplier per level
 const STYX_COLORS = ['#00FFFF', '#FF00FF', '#FFFFFF'];   // CGA cycle
 
 /* ---- Helpers ------------------------------------------------------------- */
@@ -114,7 +115,7 @@ const styxEnemies = [];
 
 function initStyxEnemies(level, claimedCells) {
   styxEnemies.length = 0;
-  const count = Math.min(1 + (level - 1), 3);
+  const count = level >= 3 ? Math.min(level - 1, 3) : 1;
   for (let i = 0; i < count; i++) {
     styxEnemies.push(createStyx(claimedCells));
   }
@@ -166,7 +167,7 @@ function moveStyxOneCell(styx, claimedCells) {
  * @param {{x,y}} player         - Player position
  * @param {function} onDeath     - Callback: called when Styx hits in-progress line
  */
-function updateStyxEnemies(dt, claimedCells, currentLine, player, onDeath) {
+function updateStyxEnemies(dt, claimedCells, currentLine, player, onDeath, level = 1) {
   for (const styx of styxEnemies) {
     // Advance animation angle
     styx.angle += dt * 3.5;
@@ -179,7 +180,8 @@ function updateStyxEnemies(dt, claimedCells, currentLine, player, onDeath) {
     }
 
     // Movement (cell-based with sub-pixel accumulation for smooth pacing)
-    styx.acc += STYX_SPEED * dt;
+    const styxSpeed = STYX_SPEED * Math.pow(STYX_SPEED_SCALE, level - 1);
+    styx.acc += styxSpeed * dt;
     while (styx.acc >= ENEMY_CELL) {
       styx.acc -= ENEMY_CELL;
       moveStyxOneCell(styx, claimedCells);
@@ -363,7 +365,7 @@ let _cachedPerimeter = [];
 function initWormEnemies(level, claimedCells) {
   wormEnemies.length = 0;
   _cachedPerimeter = buildCleanPerimeter(claimedCells);
-  const count = Math.min(1 + (level - 1), 3);
+  const count = Math.min(level, 3);
   for (let i = 0; i < count; i++) {
     const offset = Math.floor((_cachedPerimeter.length / count) * i);
     wormEnemies.push(createWorm(_cachedPerimeter, offset));

--- a/game/engine.js
+++ b/game/engine.js
@@ -55,6 +55,8 @@ const TOTAL_PLAYFIELD_CELLS = (FIELD_W_CELLS - 2) * (FIELD_H_CELLS - 2);
 let lives = 3;
 let level = 1;
 let gameOver = false;
+let levelTransition = false;  // true while level-complete overlay is showing
+let levelOverlayTimer = 0;    // seconds remaining for transition overlay
 
 /**
  * Invulnerability timer (seconds remaining after a death).
@@ -248,6 +250,8 @@ function resetGame() {
   level = 1;
   gameOver = false;
   invulnTimer = 0;
+  levelTransition = false;
+  levelOverlayTimer = 0;
   currentLine = [];
   drawMode = false;
   playerMovedThisFrame = false;
@@ -351,9 +355,35 @@ function floodFillClaim(borderLine, enemyPosition = null) {
 }
 
 // ---------------------------------------------------------------------------
+// Start next level: reset territory to border-only and respawn enemies
+// ---------------------------------------------------------------------------
+function startNextLevel() {
+  // Reset claimed territory: keep only the outer border cells
+  claimedCells.clear();
+  for (let cx = 0; cx < FIELD_W_CELLS; cx++) {
+    claimedCells.add(`${cx},0`);
+    claimedCells.add(`${cx},${FIELD_H_CELLS - 1}`);
+  }
+  for (let cy = 1; cy < FIELD_H_CELLS - 1; cy++) {
+    claimedCells.add(`0,${cy}`);
+    claimedCells.add(`${FIELD_W_CELLS - 1},${cy}`);
+  }
+  currentLine = [];
+  drawMode = false;
+  playerMovedThisFrame = false;
+  player.x = FIELD_LEFT;
+  player.y = FIELD_TOP;
+  resetFuse();
+  initStyxEnemies(level, claimedCells);
+  initWormEnemies(level, claimedCells);
+  levelTransition = false;
+}
+
+// ---------------------------------------------------------------------------
 // Check and dispatch level-complete event
 // ---------------------------------------------------------------------------
 function checkLevelComplete() {
+  if (levelTransition) return;  // already transitioning — don't fire again
   const percentage = (claimedCells.size / TOTAL_PLAYFIELD_CELLS) * 100;
   if (percentage >= 80) {
     window.dispatchEvent(new CustomEvent('level-complete', {
@@ -361,6 +391,16 @@ function checkLevelComplete() {
     }));
   }
 }
+
+// ---------------------------------------------------------------------------
+// Level-complete event listener
+// ---------------------------------------------------------------------------
+window.addEventListener('level-complete', function () {
+  level += 1;
+  levelTransition = true;
+  levelOverlayTimer = 1.5;
+});
+
 
 // ---------------------------------------------------------------------------
 // Input handling
@@ -543,6 +583,19 @@ function renderHUD() {
   }
 }
 
+function renderLevelTransition() {
+  ctx.fillStyle = 'rgba(0,0,0,0.75)';
+  ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+  ctx.fillStyle = CGA.CYAN;
+  ctx.font = 'bold 48px monospace';
+  ctx.textAlign = 'center';
+  ctx.fillText(`LEVEL ${level}`, CANVAS_W / 2, CANVAS_H / 2 - 20);
+  ctx.fillStyle = CGA.WHITE;
+  ctx.font = 'bold 16px monospace';
+  ctx.fillText('GET READY!', CANVAS_W / 2, CANVAS_H / 2 + 20);
+  ctx.textAlign = 'left';
+}
+
 function renderGameOver() {
   ctx.fillStyle = 'rgba(0,0,0,0.6)';
   ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
@@ -592,6 +645,9 @@ function render() {
   // HUD overlay
   renderHUD();
 
+  if (levelTransition) {
+    renderLevelTransition();
+  }
   if (gameOver) {
     renderGameOver();
   }
@@ -607,14 +663,22 @@ function gameLoop(timestamp) {
   lastTime = timestamp;
 
   if (!gameOver) {
-    // Tick down invulnerability timer
-    if (invulnTimer > 0) {
-      invulnTimer = Math.max(0, invulnTimer - dt);
-    }
+    // Handle level transition timer
+    if (levelTransition) {
+      levelOverlayTimer = Math.max(0, levelOverlayTimer - dt);
+      if (levelOverlayTimer <= 0) {
+        startNextLevel();
+      }
+    } else {
+      // Tick down invulnerability timer
+      if (invulnTimer > 0) {
+        invulnTimer = Math.max(0, invulnTimer - dt);
+      }
 
-    updateFuse(dt, drawMode, playerMovedThisFrame, currentLine, player, triggerDeath);
-    updateStyxEnemies(dt, claimedCells, currentLine, player, triggerDeath);
-    updateWormEnemies(dt, claimedCells, player, triggerDeath, level);
+      updateFuse(dt, drawMode, playerMovedThisFrame, currentLine, player, triggerDeath);
+      updateStyxEnemies(dt, claimedCells, currentLine, player, triggerDeath, level);
+      updateWormEnemies(dt, claimedCells, player, triggerDeath, level);
+    }
   }
 
   // Reset per-frame movement flag after fuse has read it


### PR DESCRIPTION
## Summary

Implements progressive difficulty ramp as levels increase — faster enemies, more Styx and Worms appearing at higher levels.

## Changes

### `game/enemies.js`
- Added `STYX_SPEED_SCALE = 1.15` constant (speed multiplier per level)
- Updated `updateStyxEnemies` to accept `level` parameter and scale Styx speed by `1.15^(level-1)`
- Fixed `initStyxEnemies` count: L1-2 = 1 Styx, L3 = 2 Styx, L4+ = 3 Styx
- Fixed `initWormEnemies` count: L1 = 1 Worm, L2 = 2 Worms, L3+ = 3 Worms  
- Worm speed already scaled via `WORM_BASE_SPEED + (level-1) * WORM_SPEED_DELTA`

### `game/engine.js`
- Added `levelTransition` flag and `levelOverlayTimer` state variables
- Added `startNextLevel()`: resets claimed territory to border-only, respawns enemies at new level difficulty
- Added `window 'level-complete'` event listener: increments `level`, starts 1.5s transition overlay
- Game loop: pauses enemy updates during `levelTransition`; ticks down `levelOverlayTimer`; calls `startNextLevel()` when timer expires
- `render()`: shows CYAN `LEVEL X / GET READY!` overlay during transition
- `checkLevelComplete()`: guards against double-firing during `levelTransition`
- `resetGame()`: resets `levelTransition = false`, `levelOverlayTimer = 0`, `level = 1`
- Passes `level` to `updateStyxEnemies()` call in game loop

## Acceptance Criteria

- [x] Each new level: enemy speed multiplied by ~1.15x per level
- [x] Level 2: 1 Styx / 2 Worms. Level 3: 2 Styx / 3 Worms. Level 4+: 3 Styx / 3 Worms
- [x] Level transition briefly shows level number before enemies respawn (1.5s CYAN overlay)
- [x] Difficulty ramps quickly — faithful to the original (very hard by level 3-4)

Closes #15