### PR TITLE
feat: score system and full HUD overlay (closes #22)

### DIFF
--- a/game/engine.js
+++ b/game/engine.js
@@ -249,6 +249,7 @@ function triggerDeath() {
 
   if (lives <= 0) {
     gameOver = true;
+    score = 0;
     player.x = FIELD_LEFT;
     player.y = FIELD_TOP;
     window.dispatchEvent(new CustomEvent('game-over'));
@@ -281,6 +282,9 @@ function resetGame() {
   player.x = FIELD_LEFT;
   player.y = FIELD_TOP;
   resetFuse();
+  score = 0;
+  multiplierIndex = 0;
+  multiplierTimer = 0;
   initStyxEnemies(level, claimedCells);
   initWormEnemies(level, claimedCells);
 }


### PR DESCRIPTION
## Summary

Completes issue #22 — score calculation system and full HUD overlay.

## What was already in place (from #21)
- `score` variable, `SCORE_BASE`, `MULTIPLIER_VALUES/COLORS`
- Score incremented on each `floodFillClaim` call: `claimedArea% × SCORE_BASE × multiplier`
- HUD rendering Territory%, Level, Score, Lives icons — all 4 elements already present

## Changes in this PR

- **`triggerDeath()`**: Add `score = 0` in the `lives <= 0` (game over) branch so score resets when a new game begins
- **`resetGame()`**: Add `score = 0`, `multiplierIndex = 0`, `multiplierTimer = 0` so full state is clean on play-again

## Acceptance Criteria

- [x] Score persists across levels (score never reset between levels)
- [x] Score resets to 0 on game over / play-again
- [x] HUD shows SCORE, LEVEL, LIVES, TERRITORY% during gameplay
- [x] Score updates immediately on each territory claim
- [x] HUD uses CGA palette, rendered in top strip, doesn't obscure playfield

Closes #22