### PR TITLE
feat: procedural sound effects via Web Audio API (closes #24)

### DIFF
--- a/game/audio.js
+++ b/game/audio.js
@@ -1,1 +1,166 @@
-// TODO: implement — audio (sound effects and music)
+/**
+ * audio.js — Procedural sound effects via Web Audio API (issue #24)
+ *
+ * All sounds are synthesized with oscillators/noise — zero audio file dependencies.
+ * AudioContext is lazily created on the first user interaction (browser autoplay compliance).
+ */
+
+'use strict';
+
+// ---------------------------------------------------------------------------
+// AudioContext — created on first keypress/click, then reused
+// ---------------------------------------------------------------------------
+
+let _ctx = null;
+
+/** Return the shared AudioContext, creating it on first call. */
+function getAudioContext() {
+  if (!_ctx) {
+    _ctx = new (window.AudioContext || window.webkitAudioContext)();
+  }
+  // Resume if suspended (Chrome autoplay policy)
+  if (_ctx.state === 'suspended') {
+    _ctx.resume();
+  }
+  return _ctx;
+}
+
+// Unlock AudioContext on first user interaction so later calls are instant.
+['keydown', 'mousedown', 'touchstart'].forEach(evt => {
+  window.addEventListener(evt, () => getAudioContext(), { once: false, passive: true });
+});
+
+// ---------------------------------------------------------------------------
+// Low-level helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Play a single oscillator tone.
+ * @param {string} type   - OscillatorType ('square'|'sawtooth'|'sine'|'triangle')
+ * @param {number} freq   - Start frequency in Hz
+ * @param {number} endFreq - End frequency Hz (for frequency ramp; same as freq for constant)
+ * @param {number} duration - Duration in seconds
+ * @param {number} gain   - Peak gain (0–1)
+ */
+function playTone(type, freq, endFreq, duration, gain = 0.3) {
+  const ctx = getAudioContext();
+  const now = ctx.currentTime;
+
+  const osc = ctx.createOscillator();
+  const gainNode = ctx.createGain();
+
+  osc.type = type;
+  osc.frequency.setValueAtTime(freq, now);
+  if (endFreq !== freq) {
+    osc.frequency.exponentialRampToValueAtTime(Math.max(endFreq, 1), now + duration);
+  }
+
+  gainNode.gain.setValueAtTime(gain, now);
+  gainNode.gain.exponentialRampToValueAtTime(0.001, now + duration);
+
+  osc.connect(gainNode);
+  gainNode.connect(ctx.destination);
+
+  osc.start(now);
+  osc.stop(now + duration);
+}
+
+/**
+ * Play a burst of white noise.
+ * @param {number} duration - Duration in seconds
+ * @param {number} gain     - Peak gain (0–1)
+ */
+function playNoise(duration, gain = 0.2) {
+  const ctx = getAudioContext();
+  const now = ctx.currentTime;
+  const sampleRate = ctx.sampleRate;
+  const bufferSize = Math.ceil(sampleRate * duration);
+
+  const buffer = ctx.createBuffer(1, bufferSize, sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < bufferSize; i++) {
+    data[i] = Math.random() * 2 - 1;
+  }
+
+  const source = ctx.createBufferSource();
+  source.buffer = buffer;
+
+  // Low-pass filter to shape the crunch
+  const filter = ctx.createBiquadFilter();
+  filter.type = 'lowpass';
+  filter.frequency.setValueAtTime(800, now);
+  filter.frequency.exponentialRampToValueAtTime(80, now + duration);
+
+  const gainNode = ctx.createGain();
+  gainNode.gain.setValueAtTime(gain, now);
+  gainNode.gain.exponentialRampToValueAtTime(0.001, now + duration);
+
+  source.connect(filter);
+  filter.connect(gainNode);
+  gainNode.connect(ctx.destination);
+
+  source.start(now);
+}
+
+// ---------------------------------------------------------------------------
+// Public sound effects
+// ---------------------------------------------------------------------------
+
+/**
+ * Draw start — short rising boop (~100ms, square wave).
+ * Fires when SPACEBAR activates draw mode.
+ */
+function sfxDrawStart() {
+  playTone('square', 220, 440, 0.10, 0.25);
+}
+
+/**
+ * Territory claim — descending sweep (~300ms, sawtooth).
+ * Fires when flood-fill completes and territory is claimed.
+ */
+function sfxTerritoryClaim() {
+  playTone('sawtooth', 880, 220, 0.30, 0.30);
+}
+
+/**
+ * Fuse ignition — harsh buzz (~150ms, square wave, lower freq).
+ * Fires when the Fuse enemy starts ticking (draw mode begins).
+ */
+function sfxFuseIgnition() {
+  playTone('square', 110, 90, 0.15, 0.35);
+}
+
+/**
+ * Death — crunch / descending noise (~400ms).
+ * Fires when the player loses a life.
+ */
+function sfxDeath() {
+  // Noise burst for the crunch
+  playNoise(0.40, 0.40);
+  // Descending tone underneath
+  playTone('sawtooth', 300, 40, 0.40, 0.20);
+}
+
+/**
+ * Level complete — short 3-note ascending fanfare (~600ms).
+ * Fires when 80% territory threshold is reached.
+ */
+function sfxLevelComplete() {
+  const ctx = getAudioContext();
+  const now = ctx.currentTime;
+  // Note offsets: C5, E5, G5
+  const notes = [523.25, 659.25, 783.99];
+  notes.forEach((freq, i) => {
+    const osc = ctx.createOscillator();
+    const gainNode = ctx.createGain();
+    osc.type = 'square';
+    osc.frequency.setValueAtTime(freq, now);
+    gainNode.gain.setValueAtTime(0.001, now + i * 0.18);
+    gainNode.gain.linearRampToValueAtTime(0.30, now + i * 0.18 + 0.02);
+    gainNode.gain.exponentialRampToValueAtTime(0.001, now + i * 0.18 + 0.20);
+    osc.connect(gainNode);
+    gainNode.connect(ctx.destination);
+    osc.start(now + i * 0.18);
+    osc.stop(now + i * 0.18 + 0.22);
+  });
+}

--- a/game/enemies.js
+++ b/game/enemies.js
@@ -506,6 +506,7 @@ function updateFuse(dt, drawMode, playerMoved, stixLine, player, onDeath) {
       // Ignite! Fuse starts at position 0 (beginning of stixLine)
       fuse.active   = true;
       fuse.position = 0;
+      if (typeof sfxFuseIgnition === 'function') sfxFuseIgnition();
     }
   }
 

--- a/game/engine.js
+++ b/game/engine.js
@@ -246,6 +246,7 @@ function triggerDeath() {
   resetFuse();
   multiplierIndex = 0;
   multiplierTimer = 0;
+  if (typeof sfxDeath === 'function') sfxDeath();
 
   if (lives <= 0) {
     gameOver = true;
@@ -372,6 +373,7 @@ function floodFillClaim(borderLine, enemyPosition = null) {
 
   // 5. Claim the chosen region
   regionToFill.forEach(k => claimedCells.add(k));
+  if (typeof sfxTerritoryClaim === 'function') sfxTerritoryClaim();
 
   // Award score: claimedArea% x baseScore x multiplier
   const claimedPct = (claimedCells.size / TOTAL_PLAYFIELD_CELLS) * 100;
@@ -415,6 +417,7 @@ function checkLevelComplete() {
   if (levelTransition) return;  // already transitioning — don't fire again
   const percentage = (claimedCells.size / TOTAL_PLAYFIELD_CELLS) * 100;
   if (percentage >= 80) {
+    if (typeof sfxLevelComplete === 'function') sfxLevelComplete();
     window.dispatchEvent(new CustomEvent('level-complete', {
       detail: { percentage: percentage.toFixed(1) },
     }));
@@ -454,6 +457,7 @@ window.addEventListener('keydown', function (e) {
   if (e.code === 'Space') {
     if (!drawMode) {
       drawMode = true;
+      if (typeof sfxDrawStart === 'function') sfxDrawStart();
     }
     return;
   }

--- a/game/index.html
+++ b/game/index.html
@@ -23,6 +23,7 @@
 </head>
 <body>
   <canvas id="styx-canvas" width="800" height="580"></canvas>
+  <script src="audio.js"></script>
   <script src="enemies.js"></script>
   <script src="engine.js"></script>
 </body>


### PR DESCRIPTION
## Summary

Adds synthesized retro sound effects using the Web Audio API — no external audio files required.

## Changes

### New file: `game/audio.js`
- `sfxDrawStart()` — rising boop on entering draw mode
- `sfxTerritoryClaim()` — descending sawtooth sweep on successful territory fill
- `sfxFuseIgnition()` — harsh square buzz when fuse ignites
- `sfxDeath()` — noise crunch + descending tone on player death
- `sfxLevelComplete()` — 3-note C-E-G fanfare on level completion
- `AudioContext` lazily created on first user gesture (browser autoplay policy compliance)

### `game/engine.js` hooks
- `sfxDrawStart` called when player enters draw mode
- `sfxTerritoryClaim` called on successful territory claim
- `sfxDeath` called on player death
- `sfxLevelComplete` called on level complete

### `game/enemies.js` hook
- `sfxFuseIgnition` called when The Fuse ignites

### `game/index.html`
- `audio.js` loaded before `enemies.js` and `engine.js`

## Acceptance Criteria

- [x] Sound plays on: draw start, territory claim, fuse ignition, death, level complete
- [x] AudioContext created lazily on first user interaction
- [x] All sounds synthesized — no external audio files
- [x] No console errors on load

Closes #24