### PR TITLE
fix: HUD elements visible in top strip (closes #31)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+    branches: ["**"]
+
+jobs:
+  lint:
+    name: Syntax & Lint Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: pip install streamlit
+
+      - name: Check Python syntax (app.py)
+        run: python -m py_compile app.py && echo "app.py OK"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Check JavaScript syntax
+        run: |
+          for f in game/*.js; do
+            node --check "$f" && echo "$f OK"
+          done

--- a/app.py
+++ b/app.py
@@ -1,12 +1,36 @@
 """Styx retro territory game - Streamlit wrapper."""
 import os
+import re
 import streamlit as st
 
 st.set_page_config(layout="wide", page_title="Styx")
 
-# Read the game HTML and embed it
 _dir = os.path.dirname(os.path.abspath(__file__))
-with open(os.path.join(_dir, "game", "index.html"), "r") as f:
+_game_dir = os.path.join(_dir, "game")
+
+# Read the game HTML
+with open(os.path.join(_game_dir, "index.html"), "r") as f:
     html_content = f.read()
+
+
+def _inline_scripts(html: str, game_dir: str) -> str:
+    """Replace <script src="foo.js"> tags with inline <script> blocks.
+
+    Streamlit components run in sandboxed iframes and may not resolve
+    relative script paths, so we inline all local JS files.
+    """
+    def replacer(match: re.Match) -> str:
+        src = match.group(1)
+        js_path = os.path.join(game_dir, src)
+        if os.path.isfile(js_path):
+            with open(js_path, "r") as fh:
+                js_src = fh.read()
+            return f"<script>\n{js_src}\n</script>"
+        return match.group(0)  # leave unknown src tags untouched
+
+    return re.sub(r'<script\s+src="([^"]+)"\s*></script>', replacer, html)
+
+
+html_content = _inline_scripts(html_content, _game_dir)
 
 st.components.v1.html(html_content, height=620, scrolling=False)

--- a/game/audio.js
+++ b/game/audio.js
@@ -1,1 +1,166 @@
-// TODO: implement — audio (sound effects and music)
+/**
+ * audio.js — Procedural sound effects via Web Audio API (issue #24)
+ *
+ * All sounds are synthesized with oscillators/noise — zero audio file dependencies.
+ * AudioContext is lazily created on the first user interaction (browser autoplay compliance).
+ */
+
+'use strict';
+
+// ---------------------------------------------------------------------------
+// AudioContext — created on first keypress/click, then reused
+// ---------------------------------------------------------------------------
+
+let _ctx = null;
+
+/** Return the shared AudioContext, creating it on first call. */
+function getAudioContext() {
+  if (!_ctx) {
+    _ctx = new (window.AudioContext || window.webkitAudioContext)();
+  }
+  // Resume if suspended (Chrome autoplay policy)
+  if (_ctx.state === 'suspended') {
+    _ctx.resume();
+  }
+  return _ctx;
+}
+
+// Unlock AudioContext on first user interaction so later calls are instant.
+['keydown', 'mousedown', 'touchstart'].forEach(evt => {
+  window.addEventListener(evt, () => getAudioContext(), { once: false, passive: true });
+});
+
+// ---------------------------------------------------------------------------
+// Low-level helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Play a single oscillator tone.
+ * @param {string} type   - OscillatorType ('square'|'sawtooth'|'sine'|'triangle')
+ * @param {number} freq   - Start frequency in Hz
+ * @param {number} endFreq - End frequency Hz (for frequency ramp; same as freq for constant)
+ * @param {number} duration - Duration in seconds
+ * @param {number} gain   - Peak gain (0–1)
+ */
+function playTone(type, freq, endFreq, duration, gain = 0.3) {
+  const ctx = getAudioContext();
+  const now = ctx.currentTime;
+
+  const osc = ctx.createOscillator();
+  const gainNode = ctx.createGain();
+
+  osc.type = type;
+  osc.frequency.setValueAtTime(freq, now);
+  if (endFreq !== freq) {
+    osc.frequency.exponentialRampToValueAtTime(Math.max(endFreq, 1), now + duration);
+  }
+
+  gainNode.gain.setValueAtTime(gain, now);
+  gainNode.gain.exponentialRampToValueAtTime(0.001, now + duration);
+
+  osc.connect(gainNode);
+  gainNode.connect(ctx.destination);
+
+  osc.start(now);
+  osc.stop(now + duration);
+}
+
+/**
+ * Play a burst of white noise.
+ * @param {number} duration - Duration in seconds
+ * @param {number} gain     - Peak gain (0–1)
+ */
+function playNoise(duration, gain = 0.2) {
+  const ctx = getAudioContext();
+  const now = ctx.currentTime;
+  const sampleRate = ctx.sampleRate;
+  const bufferSize = Math.ceil(sampleRate * duration);
+
+  const buffer = ctx.createBuffer(1, bufferSize, sampleRate);
+  const data = buffer.getChannelData(0);
+  for (let i = 0; i < bufferSize; i++) {
+    data[i] = Math.random() * 2 - 1;
+  }
+
+  const source = ctx.createBufferSource();
+  source.buffer = buffer;
+
+  // Low-pass filter to shape the crunch
+  const filter = ctx.createBiquadFilter();
+  filter.type = 'lowpass';
+  filter.frequency.setValueAtTime(800, now);
+  filter.frequency.exponentialRampToValueAtTime(80, now + duration);
+
+  const gainNode = ctx.createGain();
+  gainNode.gain.setValueAtTime(gain, now);
+  gainNode.gain.exponentialRampToValueAtTime(0.001, now + duration);
+
+  source.connect(filter);
+  filter.connect(gainNode);
+  gainNode.connect(ctx.destination);
+
+  source.start(now);
+}
+
+// ---------------------------------------------------------------------------
+// Public sound effects
+// ---------------------------------------------------------------------------
+
+/**
+ * Draw start — short rising boop (~100ms, square wave).
+ * Fires when SPACEBAR activates draw mode.
+ */
+function sfxDrawStart() {
+  playTone('square', 220, 440, 0.10, 0.25);
+}
+
+/**
+ * Territory claim — descending sweep (~300ms, sawtooth).
+ * Fires when flood-fill completes and territory is claimed.
+ */
+function sfxTerritoryClaim() {
+  playTone('sawtooth', 880, 220, 0.30, 0.30);
+}
+
+/**
+ * Fuse ignition — harsh buzz (~150ms, square wave, lower freq).
+ * Fires when the Fuse enemy starts ticking (draw mode begins).
+ */
+function sfxFuseIgnition() {
+  playTone('square', 110, 90, 0.15, 0.35);
+}
+
+/**
+ * Death — crunch / descending noise (~400ms).
+ * Fires when the player loses a life.
+ */
+function sfxDeath() {
+  // Noise burst for the crunch
+  playNoise(0.40, 0.40);
+  // Descending tone underneath
+  playTone('sawtooth', 300, 40, 0.40, 0.20);
+}
+
+/**
+ * Level complete — short 3-note ascending fanfare (~600ms).
+ * Fires when 80% territory threshold is reached.
+ */
+function sfxLevelComplete() {
+  const ctx = getAudioContext();
+  const now = ctx.currentTime;
+  // Note offsets: C5, E5, G5
+  const notes = [523.25, 659.25, 783.99];
+  notes.forEach((freq, i) => {
+    const osc = ctx.createOscillator();
+    const gainNode = ctx.createGain();
+    osc.type = 'square';
+    osc.frequency.setValueAtTime(freq, now);
+    gainNode.gain.setValueAtTime(0.001, now + i * 0.18);
+    gainNode.gain.linearRampToValueAtTime(0.30, now + i * 0.18 + 0.02);
+    gainNode.gain.exponentialRampToValueAtTime(0.001, now + i * 0.18 + 0.20);
+    osc.connect(gainNode);
+    gainNode.connect(ctx.destination);
+    osc.start(now + i * 0.18);
+    osc.stop(now + i * 0.18 + 0.22);
+  });
+}

--- a/game/enemies.js
+++ b/game/enemies.js
@@ -15,7 +15,7 @@
 /* ---- Constants (must match engine.js) ------------------------------------ */
 const ENEMY_CELL   = 8;
 const ENEMY_FIELD_LEFT   = 8;
-const ENEMY_FIELD_TOP    = 8;
+const ENEMY_FIELD_TOP    = 36;
 const ENEMY_FIELD_RIGHT  = 800 - 8;   // CANVAS_W - BORDER_INSET
 const ENEMY_FIELD_BOTTOM = 580 - 8;   // CANVAS_H - BORDER_INSET
 

--- a/game/enemies.js
+++ b/game/enemies.js
@@ -506,6 +506,7 @@ function updateFuse(dt, drawMode, playerMoved, stixLine, player, onDeath) {
       // Ignite! Fuse starts at position 0 (beginning of stixLine)
       fuse.active   = true;
       fuse.position = 0;
+      if (typeof sfxFuseIgnition === 'function') sfxFuseIgnition();
     }
   }
 

--- a/game/enemies.js
+++ b/game/enemies.js
@@ -436,3 +436,131 @@ function renderWormEnemies(ctx) {
     }
   }
 }
+
+
+/* ---- Constants ---------------------------------------------------------- */
+const FUSE_HESITATION_DELAY = 0.5;   // seconds before fuse ignites after player stops
+const FUSE_SPEED            = 64;    // pixels per second along the stix line
+const FUSE_FLICKER_INTERVAL = 0.05;  // seconds between color flicker alternations
+
+const FUSE_COLOR_A = '#FFFFFF';  // CGA white
+const FUSE_COLOR_B = '#00FFFF';  // CGA cyan
+
+/* ---- Fuse state ---------------------------------------------------------- */
+const fuse = {
+  active:       false,    // is the fuse currently visible/advancing?
+  position:     0,        // current position as a float index into stixLine[]
+  hesitTimer:   0,        // time the player has been stationary in draw mode
+  flickerTimer: 0,        // time accumulator for color alternation
+  flickerOn:    true,     // which flicker color to show
+  paused:       false,    // true when player is moving (fuse pauses)
+};
+
+/* ---- Public API ---------------------------------------------------------- */
+
+/** Extinguish the fuse (line completed, draw mode exited, or player died). */
+function resetFuse() {
+  fuse.active      = false;
+  fuse.position    = 0;
+  fuse.hesitTimer  = 0;
+  fuse.flickerTimer = 0;
+  fuse.flickerOn   = true;
+  fuse.paused      = false;
+}
+
+/**
+ * Update the fuse state each frame.
+ *
+ * @param {number} dt              - Delta time in seconds
+ * @param {boolean} drawMode       - Whether the player is currently in draw mode
+ * @param {boolean} playerMoved    - Whether the player moved this frame
+ * @param {Array<{x,y}>} stixLine  - The current in-progress draw line
+ * @param {{x,y}} player           - Current player position
+ * @param {function} onDeath       - Callback when fuse reaches the player
+ */
+function updateFuse(dt, drawMode, playerMoved, stixLine, player, onDeath) {
+  // Fuse is only relevant in draw mode with a line in progress
+  if (!drawMode || stixLine.length === 0) {
+    resetFuse();
+    return;
+  }
+
+  // Build the full path: stixLine + player's current position as endpoint
+  // stixLine[0] is the start (on border), stixLine[last] leads to player
+  const fullPath = [...stixLine, { x: player.x, y: player.y }];
+  const pathLen  = fullPath.length; // number of points
+
+  // Track hesitation
+  if (playerMoved) {
+    // Player is moving — pause the fuse, reset hesitation clock
+    fuse.hesitTimer = 0;
+    fuse.paused     = true;
+  } else {
+    // Player is stationary
+    fuse.paused = false;
+    fuse.hesitTimer += dt;
+
+    if (!fuse.active && fuse.hesitTimer >= FUSE_HESITATION_DELAY) {
+      // Ignite! Fuse starts at position 0 (beginning of stixLine)
+      fuse.active   = true;
+      fuse.position = 0;
+    }
+  }
+
+  if (!fuse.active) return;
+  if (fuse.paused) return;
+
+  // Advance fuse along the path
+  // Convert pixel speed to index advance: each step is CELL=8px apart,
+  // but we track by point index so advance = FUSE_SPEED/8 indices per second
+  const CELL_SIZE = 8;
+  fuse.position += (FUSE_SPEED / CELL_SIZE) * dt;
+
+  // Clamp to path end
+  if (fuse.position >= pathLen - 1) {
+    fuse.position = pathLen - 1;
+    // Reached the player
+    onDeath();
+    resetFuse();
+    return;
+  }
+
+  // Flicker update
+  fuse.flickerTimer += dt;
+  if (fuse.flickerTimer >= FUSE_FLICKER_INTERVAL) {
+    fuse.flickerTimer = 0;
+    fuse.flickerOn    = !fuse.flickerOn;
+  }
+}
+
+/**
+ * Render the fuse as a flickering pixel on the stix line.
+ *
+ * @param {CanvasRenderingContext2D} ctx
+ * @param {Array<{x,y}>} stixLine
+ * @param {{x,y}} player
+ */
+function renderFuse(ctx, stixLine, player) {
+  if (!fuse.active || stixLine.length === 0) return;
+
+  const fullPath = [...stixLine, { x: player.x, y: player.y }];
+  const idx      = Math.floor(fuse.position);
+  const point    = fullPath[Math.min(idx, fullPath.length - 1)];
+
+  const CELL_SIZE = 8;
+  const color = fuse.flickerOn ? FUSE_COLOR_A : FUSE_COLOR_B;
+
+  // Draw the fuse as a bright 2×2 pixel cluster
+  ctx.fillStyle = color;
+  ctx.fillRect(point.x + CELL_SIZE / 2 - 1, point.y + CELL_SIZE / 2 - 1, 3, 3);
+
+  // Draw a faint trail behind the fuse (last 3 path points)
+  for (let i = 1; i <= 3; i++) {
+    const trailIdx = Math.max(0, idx - i);
+    const tp = fullPath[trailIdx];
+    ctx.globalAlpha = 0.4 - i * 0.1;
+    ctx.fillStyle   = color;
+    ctx.fillRect(tp.x + CELL_SIZE / 2 - 1, tp.y + CELL_SIZE / 2 - 1, 2, 2);
+  }
+  ctx.globalAlpha = 1.0;
+}

--- a/game/enemies.js
+++ b/game/enemies.js
@@ -19,7 +19,8 @@ const ENEMY_FIELD_TOP    = 8;
 const ENEMY_FIELD_RIGHT  = 800 - 8;   // CANVAS_W - BORDER_INSET
 const ENEMY_FIELD_BOTTOM = 580 - 8;   // CANVAS_H - BORDER_INSET
 
-const STYX_SPEED = 48;   // pixels per second
+const STYX_SPEED = 48;   // pixels per second (base speed at level 1)
+const STYX_SPEED_SCALE = 1.15; // speed multiplier per level
 const STYX_COLORS = ['#00FFFF', '#FF00FF', '#FFFFFF'];   // CGA cycle
 
 /* ---- Helpers ------------------------------------------------------------- */
@@ -114,7 +115,7 @@ const styxEnemies = [];
 
 function initStyxEnemies(level, claimedCells) {
   styxEnemies.length = 0;
-  const count = Math.min(1 + (level - 1), 3);
+  const count = level >= 3 ? Math.min(level - 1, 3) : 1;
   for (let i = 0; i < count; i++) {
     styxEnemies.push(createStyx(claimedCells));
   }
@@ -166,7 +167,7 @@ function moveStyxOneCell(styx, claimedCells) {
  * @param {{x,y}} player         - Player position
  * @param {function} onDeath     - Callback: called when Styx hits in-progress line
  */
-function updateStyxEnemies(dt, claimedCells, currentLine, player, onDeath) {
+function updateStyxEnemies(dt, claimedCells, currentLine, player, onDeath, level = 1) {
   for (const styx of styxEnemies) {
     // Advance animation angle
     styx.angle += dt * 3.5;
@@ -179,7 +180,8 @@ function updateStyxEnemies(dt, claimedCells, currentLine, player, onDeath) {
     }
 
     // Movement (cell-based with sub-pixel accumulation for smooth pacing)
-    styx.acc += STYX_SPEED * dt;
+    const styxSpeed = STYX_SPEED * Math.pow(STYX_SPEED_SCALE, level - 1);
+    styx.acc += styxSpeed * dt;
     while (styx.acc >= ENEMY_CELL) {
       styx.acc -= ENEMY_CELL;
       moveStyxOneCell(styx, claimedCells);
@@ -363,7 +365,7 @@ let _cachedPerimeter = [];
 function initWormEnemies(level, claimedCells) {
   wormEnemies.length = 0;
   _cachedPerimeter = buildCleanPerimeter(claimedCells);
-  const count = Math.min(1 + (level - 1), 3);
+  const count = Math.min(level, 3);
   for (let i = 0; i < count; i++) {
     const offset = Math.floor((_cachedPerimeter.length / count) * i);
     wormEnemies.push(createWorm(_cachedPerimeter, offset));

--- a/game/enemies.js
+++ b/game/enemies.js
@@ -1,11 +1,15 @@
 /**
- * enemies.js — Styx enemy AI
+ * enemies.js — Styx enemy AI & Worm border patrol enemy
  *
  * Exports:
  *   styxEnemies      — array of active Styx enemy objects
  *   initStyxEnemies  — called on game start / level reset
  *   updateStyxEnemies(dt, claimedCells, currentLine, player, onDeath)
  *   renderStyxEnemies(ctx)
+ *   wormEnemies      — array of active Worm objects
+ *   initWormEnemies(level, claimedCells)
+ *   updateWormEnemies(dt, claimedCells, player, onDeath)
+ *   renderWormEnemies(ctx)
  */
 
 /* ---- Constants (must match engine.js) ------------------------------------ */
@@ -217,5 +221,218 @@ function renderStyxEnemies(ctx) {
     }
 
     ctx.restore();
+  }
+}
+
+
+// Base speed in pixels/second; increases with level
+const WORM_BASE_SPEED  = 64;
+const WORM_SPEED_DELTA = 16;  // additional px/s per level
+const WORM_SEGMENTS    = 4;   // number of body segments (including head)
+
+// Worm colors (CGA)
+const WORM_HEAD_COLOR = '#FFFFFF';
+const WORM_BODY_COLOR = '#FF00FF';
+
+/* ---- Helpers ------------------------------------------------------------- */
+function wSnapCell(v) {
+  return Math.round(v / ENEMY_CELL) * ENEMY_CELL;
+}
+
+function wCellKey(px, py) {
+  const cx = Math.round((px - ENEMY_FIELD_LEFT) / ENEMY_CELL);
+  const cy = Math.round((py - ENEMY_FIELD_TOP)  / ENEMY_CELL);
+  return `${cx},${cy}`;
+}
+
+/**
+ * Build the full set of perimeter positions (outer border + claimed edges)
+ * as an ordered list of {x, y} pixel coords for worm traversal.
+ *
+ * We trace the outer border clockwise, then append claimed-edge cells
+ * adjacent to the outer already-collected path.
+ */
+function buildPerimeterList(claimedCells) {
+  const perimeter = [];
+  const seen = new Set();
+
+  function add(px, py) {
+    const k = wCellKey(px, py);
+    if (seen.has(k)) return;
+    seen.add(k);
+    perimeter.push({ x: px, y: py });
+  }
+
+  // Outer border: top row left→right
+  for (let x = ENEMY_FIELD_LEFT; x <= ENEMY_FIELD_RIGHT - ENEMY_CELL; x += ENEMY_CELL) {
+    add(x, ENEMY_FIELD_TOP);
+  }
+  // Right column top→bottom
+  for (let y = ENEMY_FIELD_TOP; y <= ENEMY_FIELD_BOTTOM - ENEMY_CELL; y += ENEMY_CELL) {
+    add(ENEMY_FIELD_RIGHT - ENEMY_CELL, y);
+  }
+  // Bottom row right→left
+  for (let x = ENEMY_FIELD_RIGHT - ENEMY_CELL; x >= ENEMY_FIELD_LEFT; x -= ENEMY_CELL) {
+    add(x, ENEMY_FIELD_BOTTOM - ENEMY_CELL);
+  }
+  // Left column bottom→top
+  for (let y = ENEMY_FIELD_BOTTOM - ENEMY_CELL; y >= ENEMY_FIELD_TOP; y -= ENEMY_CELL) {
+    add(y === ENEMY_FIELD_TOP ? 0 : ENEMY_FIELD_LEFT, y); // avoid double-add corner
+    // Fix: just use correct x
+  }
+
+  // Rebuild left column properly
+  // (redo — the above had a bug; just do a clean ordered traversal)
+  return buildCleanPerimeter(claimedCells);
+}
+
+function buildCleanPerimeter(claimedCells) {
+  const positions = [];
+  const seen = new Set();
+
+  function tryAdd(px, py) {
+    const k = `${px},${py}`;
+    if (seen.has(k)) return;
+    seen.add(k);
+    positions.push({ x: px, y: py });
+  }
+
+  // Outer border clockwise
+  for (let x = ENEMY_FIELD_LEFT; x < ENEMY_FIELD_RIGHT; x += ENEMY_CELL)
+    tryAdd(x, ENEMY_FIELD_TOP);
+  for (let y = ENEMY_FIELD_TOP; y < ENEMY_FIELD_BOTTOM; y += ENEMY_CELL)
+    tryAdd(ENEMY_FIELD_RIGHT - ENEMY_CELL, y);
+  for (let x = ENEMY_FIELD_RIGHT - ENEMY_CELL; x >= ENEMY_FIELD_LEFT; x -= ENEMY_CELL)
+    tryAdd(x, ENEMY_FIELD_BOTTOM - ENEMY_CELL);
+  for (let y = ENEMY_FIELD_BOTTOM - ENEMY_CELL; y > ENEMY_FIELD_TOP; y -= ENEMY_CELL)
+    tryAdd(ENEMY_FIELD_LEFT, y);
+
+  // Claimed-edge cells (cells that are claimed but adjoin unclaimed interior)
+  if (claimedCells && claimedCells.size > 0) {
+    const fieldWCells = (ENEMY_FIELD_RIGHT - ENEMY_FIELD_LEFT) / ENEMY_CELL;
+    const fieldHCells = (ENEMY_FIELD_BOTTOM - ENEMY_FIELD_TOP) / ENEMY_CELL;
+    for (let cx = 1; cx < fieldWCells - 1; cx++) {
+      for (let cy = 1; cy < fieldHCells - 1; cy++) {
+        const k = `${cx},${cy}`;
+        if (!claimedCells.has(k)) continue;
+        // Check cardinal neighbours for unclaimed interior
+        const neighbours = [
+          [cx-1,cy],[cx+1,cy],[cx,cy-1],[cx,cy+1],
+        ];
+        const isEdge = neighbours.some(([nx, ny]) => {
+          if (nx < 1 || ny < 1 || nx >= fieldWCells-1 || ny >= fieldHCells-1) return false;
+          return !claimedCells.has(`${nx},${ny}`);
+        });
+        if (isEdge) {
+          const px = ENEMY_FIELD_LEFT + cx * ENEMY_CELL;
+          const py = ENEMY_FIELD_TOP  + cy * ENEMY_CELL;
+          tryAdd(px, py);
+        }
+      }
+    }
+  }
+
+  return positions;
+}
+
+/* ---- Worm object --------------------------------------------------------- */
+
+function createWorm(perimeterList, offset) {
+  // segments[0] = head; segments[N] = tail
+  const startIdx = offset % perimeterList.length;
+  const segments = [];
+  for (let i = 0; i < WORM_SEGMENTS; i++) {
+    const idx = (startIdx - i + perimeterList.length) % perimeterList.length;
+    segments.push({ ...perimeterList[idx] });
+  }
+  return {
+    segments,
+    perimIdx: startIdx,   // index of head in perimeter list
+    acc: 0,
+    // direction: +1 = forward along perimeter, -1 = backward
+    dir: Math.random() < 0.5 ? 1 : -1,
+    // how long until next direction change
+    dirTimer: 2 + Math.random() * 4,
+  };
+}
+
+/* ---- Module state -------------------------------------------------------- */
+const wormEnemies = [];
+let _cachedPerimeter = [];
+
+function initWormEnemies(level, claimedCells) {
+  wormEnemies.length = 0;
+  _cachedPerimeter = buildCleanPerimeter(claimedCells);
+  const count = Math.min(1 + (level - 1), 3);
+  for (let i = 0; i < count; i++) {
+    const offset = Math.floor((_cachedPerimeter.length / count) * i);
+    wormEnemies.push(createWorm(_cachedPerimeter, offset));
+  }
+}
+
+/**
+ * Update worm positions and check player collision.
+ *
+ * @param {number} dt
+ * @param {Set<string>} claimedCells
+ * @param {{x,y}} player
+ * @param {function} onDeath
+ */
+function updateWormEnemies(dt, claimedCells, player, onDeath, level = 1) {
+  // Rebuild perimeter on claimed-territory changes
+  _cachedPerimeter = buildCleanPerimeter(claimedCells);
+  if (_cachedPerimeter.length === 0) return;
+
+  const speed = WORM_BASE_SPEED + (level - 1) * WORM_SPEED_DELTA;
+
+  for (const worm of wormEnemies) {
+    // Direction change timer
+    worm.dirTimer -= dt;
+    if (worm.dirTimer <= 0) {
+      worm.dir = -worm.dir;
+      worm.dirTimer = 2 + Math.random() * 4;
+    }
+
+    // Advance by speed * dt cells
+    worm.acc += speed * dt;
+    while (worm.acc >= ENEMY_CELL) {
+      worm.acc -= ENEMY_CELL;
+      // Move head one step along perimeter
+      worm.perimIdx = (worm.perimIdx + worm.dir + _cachedPerimeter.length) % _cachedPerimeter.length;
+      const headPos = _cachedPerimeter[worm.perimIdx];
+
+      // Shift segments: new head, drop last
+      worm.segments.unshift({ x: headPos.x, y: headPos.y });
+      worm.segments.length = WORM_SEGMENTS;
+    }
+
+    // Collision with player (any segment)
+    const hit = worm.segments.some(
+      s => Math.abs(s.x - player.x) < ENEMY_CELL && Math.abs(s.y - player.y) < ENEMY_CELL
+    );
+    if (hit) {
+      onDeath();
+    }
+  }
+}
+
+/**
+ * Render worm enemies.
+ * @param {CanvasRenderingContext2D} ctx
+ */
+function renderWormEnemies(ctx) {
+  for (const worm of wormEnemies) {
+    for (let i = 0; i < worm.segments.length; i++) {
+      const seg = worm.segments[i];
+      ctx.fillStyle = i === 0 ? WORM_HEAD_COLOR : WORM_BODY_COLOR;
+      ctx.fillRect(seg.x, seg.y, ENEMY_CELL, ENEMY_CELL);
+      // Draw segment divider
+      if (i > 0) {
+        ctx.fillStyle = '#000000';
+        ctx.fillRect(seg.x + 1, seg.y + 1, ENEMY_CELL - 2, ENEMY_CELL - 2);
+        ctx.fillStyle = i === 0 ? WORM_HEAD_COLOR : WORM_BODY_COLOR;
+        ctx.fillRect(seg.x + 2, seg.y + 2, ENEMY_CELL - 4, ENEMY_CELL - 4);
+      }
+    }
   }
 }

--- a/game/enemies.js
+++ b/game/enemies.js
@@ -1,1 +1,221 @@
-// TODO: implement — Styx enemy AI and movement
+/**
+ * enemies.js — Styx enemy AI
+ *
+ * Exports:
+ *   styxEnemies      — array of active Styx enemy objects
+ *   initStyxEnemies  — called on game start / level reset
+ *   updateStyxEnemies(dt, claimedCells, currentLine, player, onDeath)
+ *   renderStyxEnemies(ctx)
+ */
+
+/* ---- Constants (must match engine.js) ------------------------------------ */
+const ENEMY_CELL   = 8;
+const ENEMY_FIELD_LEFT   = 8;
+const ENEMY_FIELD_TOP    = 8;
+const ENEMY_FIELD_RIGHT  = 800 - 8;   // CANVAS_W - BORDER_INSET
+const ENEMY_FIELD_BOTTOM = 580 - 8;   // CANVAS_H - BORDER_INSET
+
+const STYX_SPEED = 48;   // pixels per second
+const STYX_COLORS = ['#00FFFF', '#FF00FF', '#FFFFFF'];   // CGA cycle
+
+/* ---- Helpers ------------------------------------------------------------- */
+function snapCell(v) {
+  return Math.round(v / ENEMY_CELL) * ENEMY_CELL;
+}
+
+function cellKeyE(px, py) {
+  const cx = Math.round((px - ENEMY_FIELD_LEFT) / ENEMY_CELL);
+  const cy = Math.round((py - ENEMY_FIELD_TOP)  / ENEMY_CELL);
+  return `${cx},${cy}`;
+}
+
+function isClaimed(px, py, claimedCells) {
+  return claimedCells.has(cellKeyE(px, py));
+}
+
+function isOuterBorder(px, py) {
+  const x = snapCell(px);
+  const y = snapCell(py);
+  const inH = x >= ENEMY_FIELD_LEFT && x <= ENEMY_FIELD_RIGHT - ENEMY_CELL;
+  const inV = y >= ENEMY_FIELD_TOP  && y <= ENEMY_FIELD_BOTTOM - ENEMY_CELL;
+  return ((x === ENEMY_FIELD_LEFT || x === ENEMY_FIELD_RIGHT - ENEMY_CELL) && inV) ||
+         ((y === ENEMY_FIELD_TOP  || y === ENEMY_FIELD_BOTTOM - ENEMY_CELL) && inH);
+}
+
+/** Returns a random axis-aligned unit-cell direction {dx, dy} */
+function randomDir() {
+  const dirs = [
+    { dx:  ENEMY_CELL, dy: 0 },
+    { dx: -ENEMY_CELL, dy: 0 },
+    { dx: 0, dy:  ENEMY_CELL },
+    { dx: 0, dy: -ENEMY_CELL },
+  ];
+  return dirs[Math.floor(Math.random() * dirs.length)];
+}
+
+/** Clamp to interior (not outer border) */
+function clampInterior(x, y) {
+  return {
+    x: Math.max(ENEMY_FIELD_LEFT + ENEMY_CELL,
+                Math.min(ENEMY_FIELD_RIGHT  - ENEMY_CELL * 2, snapCell(x))),
+    y: Math.max(ENEMY_FIELD_TOP  + ENEMY_CELL,
+                Math.min(ENEMY_FIELD_BOTTOM - ENEMY_CELL * 2, snapCell(y))),
+  };
+}
+
+/** Pick a random unclaimed interior start position */
+function randomInteriorPos(claimedCells) {
+  const maxTries = 200;
+  for (let i = 0; i < maxTries; i++) {
+    const fwCells = (ENEMY_FIELD_RIGHT  - ENEMY_FIELD_LEFT) / ENEMY_CELL;
+    const fhCells = (ENEMY_FIELD_BOTTOM - ENEMY_FIELD_TOP)  / ENEMY_CELL;
+    const cx = 1 + Math.floor(Math.random() * (fwCells - 2));
+    const cy = 1 + Math.floor(Math.random() * (fhCells - 2));
+    const px = ENEMY_FIELD_LEFT + cx * ENEMY_CELL;
+    const py = ENEMY_FIELD_TOP  + cy * ENEMY_CELL;
+    if (!isClaimed(px, py, claimedCells) && !isOuterBorder(px, py)) {
+      return { x: px, y: py };
+    }
+  }
+  // Fallback: near-centre
+  return clampInterior(
+    ENEMY_FIELD_LEFT + (ENEMY_FIELD_RIGHT  - ENEMY_FIELD_LEFT) / 2,
+    ENEMY_FIELD_TOP  + (ENEMY_FIELD_BOTTOM - ENEMY_FIELD_TOP)  / 2,
+  );
+}
+
+/* ---- Styx enemy object --------------------------------------------------- */
+
+function createStyx(claimedCells) {
+  const pos = randomInteriorPos(claimedCells);
+  const dir = randomDir();
+  return {
+    x: pos.x,
+    y: pos.y,
+    // sub-pixel accumulator for smooth movement
+    acc: 0,
+    dx: dir.dx,
+    dy: dir.dy,
+    // visual: 3–5 line segments per Styx
+    numSegments: 3 + Math.floor(Math.random() * 3),
+    // angle offset for animation
+    angle: Math.random() * Math.PI * 2,
+    colorIdx: Math.floor(Math.random() * STYX_COLORS.length),
+    colorTimer: 0,
+  };
+}
+
+/* ---- Module state -------------------------------------------------------- */
+const styxEnemies = [];
+
+function initStyxEnemies(level, claimedCells) {
+  styxEnemies.length = 0;
+  const count = Math.min(1 + (level - 1), 3);
+  for (let i = 0; i < count; i++) {
+    styxEnemies.push(createStyx(claimedCells));
+  }
+}
+
+/**
+ * Move a single Styx one cell in its current direction.
+ * If the destination is a claimed cell, outer border, or out of bounds,
+ * pick a new random direction and try again (up to 4 tries).
+ */
+function moveStyxOneCell(styx, claimedCells) {
+  const dirs = [
+    { dx: styx.dx, dy: styx.dy },
+    ...([
+      { dx: ENEMY_CELL, dy: 0 }, { dx: -ENEMY_CELL, dy: 0 },
+      { dx: 0, dy: ENEMY_CELL }, { dx: 0, dy: -ENEMY_CELL },
+    ].filter(d => d.dx !== styx.dx || d.dy !== styx.dy)
+      .sort(() => Math.random() - 0.5)),
+  ];
+
+  for (const d of dirs) {
+    const nx = styx.x + d.dx;
+    const ny = styx.y + d.dy;
+    const inBounds =
+      nx >= ENEMY_FIELD_LEFT + ENEMY_CELL &&
+      nx <= ENEMY_FIELD_RIGHT - ENEMY_CELL * 2 &&
+      ny >= ENEMY_FIELD_TOP  + ENEMY_CELL &&
+      ny <= ENEMY_FIELD_BOTTOM - ENEMY_CELL * 2;
+    if (inBounds && !isClaimed(nx, ny, claimedCells) && !isOuterBorder(nx, ny)) {
+      styx.x  = nx;
+      styx.y  = ny;
+      styx.dx = d.dx;
+      styx.dy = d.dy;
+      return;
+    }
+  }
+  // Completely boxed in — stay put and pick new random dir
+  const d = randomDir();
+  styx.dx = d.dx;
+  styx.dy = d.dy;
+}
+
+/**
+ * Update all Styx enemies.
+ *
+ * @param {number} dt             - Delta time in seconds
+ * @param {Set<string>} claimedCells - Claimed cell keys from engine
+ * @param {Array<{x,y}>} currentLine - Player's in-progress draw line
+ * @param {{x,y}} player         - Player position
+ * @param {function} onDeath     - Callback: called when Styx hits in-progress line
+ */
+function updateStyxEnemies(dt, claimedCells, currentLine, player, onDeath) {
+  for (const styx of styxEnemies) {
+    // Advance animation angle
+    styx.angle += dt * 3.5;
+
+    // Color cycling
+    styx.colorTimer += dt;
+    if (styx.colorTimer > 0.12) {
+      styx.colorTimer = 0;
+      styx.colorIdx = (styx.colorIdx + 1) % STYX_COLORS.length;
+    }
+
+    // Movement (cell-based with sub-pixel accumulation for smooth pacing)
+    styx.acc += STYX_SPEED * dt;
+    while (styx.acc >= ENEMY_CELL) {
+      styx.acc -= ENEMY_CELL;
+      moveStyxOneCell(styx, claimedCells);
+    }
+
+    // Collision: does Styx overlap any cell of the in-progress draw line?
+    if (currentLine.length > 0) {
+      const hit = currentLine.some(
+        p => Math.abs(p.x - styx.x) < ENEMY_CELL && Math.abs(p.y - styx.y) < ENEMY_CELL
+      );
+      if (hit) {
+        onDeath();
+      }
+    }
+  }
+}
+
+/**
+ * Render all Styx enemies as animated bundles of intersecting lines.
+ * @param {CanvasRenderingContext2D} ctx
+ */
+function renderStyxEnemies(ctx) {
+  for (const styx of styxEnemies) {
+    const cx = styx.x + ENEMY_CELL / 2;
+    const cy = styx.y + ENEMY_CELL / 2;
+    const len = ENEMY_CELL * 1.2;
+
+    ctx.save();
+    ctx.lineWidth = 1.5;
+
+    for (let i = 0; i < styx.numSegments; i++) {
+      const theta = styx.angle + (i * Math.PI) / styx.numSegments;
+      const color = STYX_COLORS[(styx.colorIdx + i) % STYX_COLORS.length];
+      ctx.strokeStyle = color;
+      ctx.beginPath();
+      ctx.moveTo(cx + Math.cos(theta) * len,       cy + Math.sin(theta) * len);
+      ctx.lineTo(cx + Math.cos(theta + Math.PI) * len, cy + Math.sin(theta + Math.PI) * len);
+      ctx.stroke();
+    }
+
+    ctx.restore();
+  }
+}

--- a/game/engine.js
+++ b/game/engine.js
@@ -57,6 +57,26 @@ let level = 1;
 let gameOver = false;
 let levelTransition = false;  // true while level-complete overlay is showing
 let levelOverlayTimer = 0;    // seconds remaining for transition overlay
+// ---------------------------------------------------------------------------
+// Scoring & cycling multiplier (issue #21)
+// ---------------------------------------------------------------------------
+
+/** Base score awarded per percentage-point of territory claimed */
+const SCORE_BASE = 100;
+
+/** Multiplier cycle sequence (1x -> 5x -> 10x -> 1x ...) */
+const MULTIPLIER_VALUES = [1, 5, 10];
+
+/** Display colours for each multiplier index */
+const MULTIPLIER_COLORS = [CGA.WHITE, CGA.CYAN, CGA.MAGENTA];
+
+/** Seconds per multiplier step */
+const MULTIPLIER_CYCLE_SECONDS = 2.0;
+
+let score = 0;
+let multiplierIndex = 0;
+let multiplierTimer = 0;
+
 
 /**
  * Invulnerability timer (seconds remaining after a death).
@@ -224,6 +244,8 @@ function triggerDeath() {
   drawMode = false;
   playerMovedThisFrame = false;
   resetFuse();
+  multiplierIndex = 0;
+  multiplierTimer = 0;
 
   if (lives <= 0) {
     gameOver = true;
@@ -351,6 +373,11 @@ function floodFillClaim(borderLine, enemyPosition = null) {
   // 5. Claim the chosen region
   regionToFill.forEach(k => claimedCells.add(k));
 
+  // Award score: claimedArea% x baseScore x multiplier
+  const claimedPct = (claimedCells.size / TOTAL_PLAYFIELD_CELLS) * 100;
+  const mult = MULTIPLIER_VALUES[multiplierIndex];
+  score += Math.round(claimedPct * SCORE_BASE * mult);
+
   checkLevelComplete();
 }
 
@@ -374,6 +401,8 @@ function startNextLevel() {
   player.x = FIELD_LEFT;
   player.y = FIELD_TOP;
   resetFuse();
+  multiplierIndex = 0;
+  multiplierTimer = 0;
   initStyxEnemies(level, claimedCells);
   initWormEnemies(level, claimedCells);
   levelTransition = false;
@@ -571,6 +600,19 @@ function renderHUD() {
   ctx.font = 'bold 13px monospace';
   ctx.fillText(`Territory: ${percentage}%`, FIELD_LEFT + 4, FIELD_TOP - 2);
   ctx.fillText(`Level: ${level}`, FIELD_LEFT + 160, FIELD_TOP - 2);
+  ctx.fillText(`Score: ${score}`, FIELD_LEFT + 260, FIELD_TOP - 2);
+
+  // Cycling multiplier block -- left of the lives icons
+  const multVal   = MULTIPLIER_VALUES[multiplierIndex];
+  const multColor = MULTIPLIER_COLORS[multiplierIndex];
+  const blockSize = CELL + 2;
+  const multX = FIELD_RIGHT - (lives * (CELL + 2)) - blockSize - 16;
+  const multY = BORDER_INSET - blockSize;
+  ctx.fillStyle = multColor;
+  ctx.fillRect(multX, multY, blockSize, blockSize);
+  ctx.fillStyle = CGA.BLACK;
+  ctx.font = 'bold 9px monospace';
+  ctx.fillText(`${multVal}x`, multX + 1, multY + 9);
 
   // Lives as MAGENTA block icons in the top-right
   const iconSize = CELL;
@@ -673,6 +715,12 @@ function gameLoop(timestamp) {
       // Tick down invulnerability timer
       if (invulnTimer > 0) {
         invulnTimer = Math.max(0, invulnTimer - dt);
+      }
+      // Advance cycling multiplier
+      multiplierTimer += dt;
+      if (multiplierTimer >= MULTIPLIER_CYCLE_SECONDS) {
+        multiplierTimer -= MULTIPLIER_CYCLE_SECONDS;
+        multiplierIndex = (multiplierIndex + 1) % MULTIPLIER_VALUES.length;
       }
 
       updateFuse(dt, drawMode, playerMovedThisFrame, currentLine, player, triggerDeath);

--- a/game/engine.js
+++ b/game/engine.js
@@ -5,7 +5,8 @@
  * flood-fill territory claiming & HUD (issue #5),
  * Styx field enemy (issue #11),
  * Worm border patrol enemy (issue #12),
- * Fuse hesitation penalty (issue #13).
+ * Fuse hesitation penalty (issue #13),
+ * Collision detection & life system (issue #14).
  */
 
 // CGA palette constants — all colour references must use these
@@ -54,6 +55,12 @@ const TOTAL_PLAYFIELD_CELLS = (FIELD_W_CELLS - 2) * (FIELD_H_CELLS - 2);
 let lives = 3;
 let level = 1;
 let gameOver = false;
+
+/**
+ * Invulnerability timer (seconds remaining after a death).
+ * While > 0, triggerDeath() is a no-op — prevents double-kills.
+ */
+let invulnTimer = 0;
 
 // ---------------------------------------------------------------------------
 // Player state
@@ -167,24 +174,89 @@ function isOnSafeEdge(px, py) {
 }
 
 // ---------------------------------------------------------------------------
+// Helper: find nearest border position to (px, py) using Euclidean distance.
+// Searches all 4 edges and returns the closest grid-snapped position.
+// ---------------------------------------------------------------------------
+function nearestBorderPosition(px, py) {
+  let bestDist = Infinity;
+  let bestX = FIELD_LEFT;
+  let bestY = FIELD_TOP;
+
+  function check(bx, by) {
+    const dx = px - bx;
+    const dy = py - by;
+    const d = dx * dx + dy * dy;
+    if (d < bestDist) {
+      bestDist = d;
+      bestX = bx;
+      bestY = by;
+    }
+  }
+
+  // Top edge
+  for (let x = FIELD_LEFT; x <= FIELD_RIGHT - CELL; x += CELL) check(x, FIELD_TOP);
+  // Bottom edge
+  for (let x = FIELD_LEFT; x <= FIELD_RIGHT - CELL; x += CELL) check(x, FIELD_BOTTOM - CELL);
+  // Left edge (skip corners already covered)
+  for (let y = FIELD_TOP + CELL; y <= FIELD_BOTTOM - CELL * 2; y += CELL) check(FIELD_LEFT, y);
+  // Right edge
+  for (let y = FIELD_TOP + CELL; y <= FIELD_BOTTOM - CELL * 2; y += CELL) check(FIELD_RIGHT - CELL, y);
+
+  return { x: bestX, y: bestY };
+}
+
+// ---------------------------------------------------------------------------
 // Death & reset
 // ---------------------------------------------------------------------------
 
 /**
- * Handle player death: lose a life, reset draw state, snap player to border.
+ * Handle player death: lose a life, reset draw state, snap player to nearest
+ * border position, start invulnerability window.
+ * No-op if invulnerability window is still active.
  */
 function triggerDeath() {
+  if (invulnTimer > 0) return;  // still invulnerable — ignore
+
   lives -= 1;
   currentLine = [];
   drawMode = false;
   playerMovedThisFrame = false;
   resetFuse();
-  player.x = FIELD_LEFT;
-  player.y = FIELD_TOP;
+
   if (lives <= 0) {
     gameOver = true;
+    player.x = FIELD_LEFT;
+    player.y = FIELD_TOP;
     window.dispatchEvent(new CustomEvent('game-over'));
+    return;
   }
+
+  // Respawn at nearest border position
+  const respawn = nearestBorderPosition(player.x, player.y);
+  player.x = respawn.x;
+  player.y = respawn.y;
+
+  // 1.5s invulnerability window
+  invulnTimer = 1.5;
+}
+
+// ---------------------------------------------------------------------------
+// Full game reset (called on play-again)
+// ---------------------------------------------------------------------------
+function resetGame() {
+  lives = 3;
+  level = 1;
+  gameOver = false;
+  invulnTimer = 0;
+  currentLine = [];
+  drawMode = false;
+  playerMovedThisFrame = false;
+  claimedCells.clear();
+  player.x = FIELD_LEFT;
+  player.y = FIELD_TOP;
+  resetFuse();
+  initStyxEnemies(level, claimedCells);
+  initWormEnemies(level, claimedCells);
 }
 
 // ---------------------------------------------------------------------------
@@ -301,6 +373,12 @@ window.addEventListener('keydown', function (e) {
     e.preventDefault();
   }
 
+  // Play-again: R key resets game when game over
+  if (gameOver && e.code === 'KeyR') {
+    resetGame();
+    return;
+  }
+
   if (gameOver) return;
 
   // SPACEBAR activates draw mode
@@ -395,6 +473,13 @@ window.addEventListener('keyup', function (e) {
   }
 });
 
+// Play-again: click canvas when game over
+canvas.addEventListener('click', function () {
+  if (gameOver) {
+    resetGame();
+  }
+});
+
 // ---------------------------------------------------------------------------
 // Rendering
 // ---------------------------------------------------------------------------
@@ -424,23 +509,38 @@ function renderCurrentLine() {
 }
 
 /**
- * Draw the player marker — magenta 8×8 square.
+ * Draw the player as a MAGENTA filled square.
  */
 function renderPlayer() {
+  // Flash the player during invulnerability window (toggle at ~8 Hz)
+  if (invulnTimer > 0) {
+    const flash = Math.floor(invulnTimer * 8) % 2 === 0;
+    if (!flash) return;
+  }
   ctx.fillStyle = CGA.MAGENTA;
   ctx.fillRect(player.x, player.y, CELL, CELL);
 }
 
 /**
- * Draw the territory percentage and lives HUD.
+ * Draw the territory percentage, level, and lives HUD.
+ * Lives are shown as small MAGENTA player-icon squares.
  */
 function renderHUD() {
   const percentage = ((claimedCells.size / TOTAL_PLAYFIELD_CELLS) * 100).toFixed(1);
   ctx.fillStyle = CGA.WHITE;
   ctx.font = 'bold 13px monospace';
   ctx.fillText(`Territory: ${percentage}%`, FIELD_LEFT + 4, FIELD_TOP - 2);
-  ctx.fillText(`Lives: ${lives}`, FIELD_RIGHT - 80, FIELD_TOP - 2);
   ctx.fillText(`Level: ${level}`, FIELD_LEFT + 160, FIELD_TOP - 2);
+
+  // Lives as MAGENTA block icons in the top-right
+  const iconSize = CELL;
+  const iconGap  = 2;
+  const baseX    = FIELD_RIGHT - (lives * (iconSize + iconGap));
+  const baseY    = BORDER_INSET - iconSize - 1;
+  ctx.fillStyle = CGA.MAGENTA;
+  for (let i = 0; i < lives; i++) {
+    ctx.fillRect(baseX + i * (iconSize + iconGap), baseY, iconSize, iconSize);
+  }
 }
 
 function renderGameOver() {
@@ -452,7 +552,7 @@ function renderGameOver() {
   ctx.fillText('GAME OVER', CANVAS_W / 2, CANVAS_H / 2);
   ctx.fillStyle = CGA.WHITE;
   ctx.font = 'bold 16px monospace';
-  ctx.fillText('Refresh to play again', CANVAS_W / 2, CANVAS_H / 2 + 36);
+  ctx.fillText('Press R or click to play again', CANVAS_W / 2, CANVAS_H / 2 + 36);
   ctx.textAlign = 'left';
 }
 
@@ -507,6 +607,11 @@ function gameLoop(timestamp) {
   lastTime = timestamp;
 
   if (!gameOver) {
+    // Tick down invulnerability timer
+    if (invulnTimer > 0) {
+      invulnTimer = Math.max(0, invulnTimer - dt);
+    }
+
     updateFuse(dt, drawMode, playerMovedThisFrame, currentLine, player, triggerDeath);
     updateStyxEnemies(dt, claimedCells, currentLine, player, triggerDeath);
     updateWormEnemies(dt, claimedCells, player, triggerDeath, level);
@@ -525,4 +630,3 @@ window.addEventListener('load', function () {
   initWormEnemies(level, claimedCells);
   requestAnimationFrame(gameLoop);
 });
-

--- a/game/engine.js
+++ b/game/engine.js
@@ -1,7 +1,8 @@
 /**
  * engine.js — Styx core game engine
  * Canvas setup, 60fps game loop, CGA palette constants,
- * player movement (issue #3), draw mode & Stix line rendering (issue #4).
+ * player movement (issue #3), draw mode & Stix line rendering (issue #4),
+ * flood-fill territory claiming & HUD (issue #5).
  */
 
 // CGA palette constants — all colour references must use these
@@ -33,6 +34,16 @@ const FIELD_TOP    = BORDER_INSET;
 const FIELD_RIGHT  = CANVAS_W - BORDER_INSET;
 const FIELD_BOTTOM = CANVAS_H - BORDER_INSET;
 
+// Grid dimensions (number of CELL-sized slots across the playfield including border)
+const FIELD_W_CELLS = (FIELD_RIGHT - FIELD_LEFT) / CELL;
+const FIELD_H_CELLS = (FIELD_BOTTOM - FIELD_TOP) / CELL;
+
+/**
+ * Total interior (non-border) cells — used for percentage calculation.
+ * Subtract 2 on each axis to exclude the 1-cell-wide border row/column.
+ */
+const TOTAL_PLAYFIELD_CELLS = (FIELD_W_CELLS - 2) * (FIELD_H_CELLS - 2);
+
 // ---------------------------------------------------------------------------
 // Player state
 // ---------------------------------------------------------------------------
@@ -53,13 +64,18 @@ const keysHeld = new Set();
 /**
  * Current in-progress Stix draw line.
  * Array of {x, y} pixel positions tracing the path the player has drawn.
- * Populated while SPACEBAR is held and player moves.
- * Cleared when line completes (connects back to border) or SPACEBAR released.
  */
 let currentLine = [];
 
 /** True when SPACEBAR is held and player is in draw mode. */
 let drawMode = false;
+
+/**
+ * Claimed territory cells.
+ * Set of "cx,cy" grid-coordinate keys (not pixel coords).
+ * cx/cy are cell indices relative to FIELD_LEFT/FIELD_TOP.
+ */
+const claimedCells = new Set();
 
 // ---------------------------------------------------------------------------
 // Helper: snap a pixel value to the nearest CELL grid position
@@ -79,6 +95,24 @@ function clampToField(px, py) {
 }
 
 // ---------------------------------------------------------------------------
+// Helper: convert pixel position to grid cell coordinates
+// ---------------------------------------------------------------------------
+function pixelToCell(px, py) {
+  return {
+    cx: Math.round((px - FIELD_LEFT) / CELL),
+    cy: Math.round((py - FIELD_TOP)  / CELL),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: cell key from pixel position
+// ---------------------------------------------------------------------------
+function cellKey(px, py) {
+  const { cx, cy } = pixelToCell(px, py);
+  return `${cx},${cy}`;
+}
+
+// ---------------------------------------------------------------------------
 // Helper: is (px, py) on the outer border perimeter?
 // ---------------------------------------------------------------------------
 function isOnOuterBorder(px, py) {
@@ -95,22 +129,151 @@ function isOnOuterBorder(px, py) {
 }
 
 // ---------------------------------------------------------------------------
-// Helper: is (px, py) on a valid position for normal (non-draw) movement?
-// Extended in issue #5 to include claimed territory edges.
+// Helper: is (px, py) on the edge of claimed territory?
+// A claimed cell is an "edge" if at least one of its 4 cardinal neighbours
+// is an unclaimed interior cell.
 // ---------------------------------------------------------------------------
-function isOnSafeEdge(px, py) {
-  return isOnOuterBorder(px, py);
+function isOnClaimedEdge(px, py) {
+  const k = cellKey(px, py);
+  if (!claimedCells.has(k)) return false;
+  const { cx, cy } = pixelToCell(px, py);
+  const neighbours = [
+    `${cx-1},${cy}`, `${cx+1},${cy}`,
+    `${cx},${cy-1}`, `${cx},${cy+1}`,
+  ];
+  return neighbours.some(nk => !claimedCells.has(nk));
 }
 
 // ---------------------------------------------------------------------------
-// Stub: flood-fill claim — implemented in issue #5.
-// Called when the draw line connects back to a safe edge.
-//
-// @param {Array<{x:number, y:number}>} borderLine - Completed Stix line cells
-// @param {{x:number, y:number}|null} enemyPosition - See issue #5 for details
+// Helper: is (px, py) a valid position for normal (non-draw) movement?
+// Includes outer border and edges of claimed territory.
 // ---------------------------------------------------------------------------
-function floodFillClaim(borderLine, enemyPosition = null) { // eslint-disable-line no-unused-vars
-  // TODO: implement in issue #5 (flood-fill territory claiming)
+function isOnSafeEdge(px, py) {
+  return isOnOuterBorder(px, py) || isOnClaimedEdge(px, py);
+}
+
+// ---------------------------------------------------------------------------
+// Flood-fill territory claiming
+//
+// @param {Array<{x:number, y:number}>} borderLine
+//   The newly completed Stix border line (pixel positions of drawn cells).
+//   These cells form the new border between claimed and unclaimed territory.
+//
+// @param {{x:number, y:number}|null} enemyPosition
+//   Optional enemy position in pixel coordinates.
+//
+//   PHASE 1 (no enemies): pass null — the function fills the SMALLER of the
+//   two regions enclosed by the new border line + existing claimed territory.
+//   Smaller-region fill is the authentic Styx mechanic (maximises risk/reward).
+//
+//   PHASE 2 (enemies): pass the enemy's current {x, y}.
+//   The function fills the region that does NOT contain the enemy, ensuring
+//   the enemy is never trapped in claimed territory. If the enemy is on a
+//   barrier cell (already claimed), all enclosed regions are safe to fill.
+//   If multiple safe regions exist, the largest is chosen to reward the player.
+//
+//   Example Phase 2 call:
+//     floodFillClaim(completedLine, { x: enemy.x, y: enemy.y });
+// ---------------------------------------------------------------------------
+function floodFillClaim(borderLine, enemyPosition = null) {
+  // 1. Add borderLine pixels to claimedCells (they become the new wall)
+  borderLine.forEach(({ x, y }) => {
+    claimedCells.add(cellKey(x, y));
+  });
+
+  // 2. Build barrier set: outer border rows/cols + all claimed cells
+  //    Barrier = cannot be filled; flood-fill stays inside barriers.
+  const barriers = new Set(claimedCells);
+  for (let cx = 0; cx < FIELD_W_CELLS; cx++) {
+    barriers.add(`${cx},0`);
+    barriers.add(`${cx},${FIELD_H_CELLS - 1}`);
+  }
+  for (let cy = 0; cy < FIELD_H_CELLS; cy++) {
+    barriers.add(`0,${cy}`);
+    barriers.add(`${FIELD_W_CELLS - 1},${cy}`);
+  }
+
+  // 3. Flood-fill all distinct interior regions (BFS per unvisited seed)
+  const visited = new Set();
+  const regions = [];
+
+  function bfs(startCx, startCy) {
+    const region = new Set();
+    const queue = [[startCx, startCy]];
+    const startKey = `${startCx},${startCy}`;
+    visited.add(startKey);
+    region.add(startKey);
+    while (queue.length > 0) {
+      const [cx, cy] = queue.shift();
+      for (const [nx, ny] of [[cx-1,cy],[cx+1,cy],[cx,cy-1],[cx,cy+1]]) {
+        const nk = `${nx},${ny}`;
+        if (!visited.has(nk) && !barriers.has(nk) &&
+            nx >= 1 && nx < FIELD_W_CELLS - 1 &&
+            ny >= 1 && ny < FIELD_H_CELLS - 1) {
+          visited.add(nk);
+          region.add(nk);
+          queue.push([nx, ny]);
+        }
+      }
+    }
+    return region;
+  }
+
+  for (let cx = 1; cx < FIELD_W_CELLS - 1; cx++) {
+    for (let cy = 1; cy < FIELD_H_CELLS - 1; cy++) {
+      const k = `${cx},${cy}`;
+      if (!visited.has(k) && !barriers.has(k)) {
+        regions.push(bfs(cx, cy));
+      }
+    }
+  }
+
+  if (regions.length === 0) {
+    checkLevelComplete();
+    return;
+  }
+
+  // 4. Choose which region to fill
+  let regionToFill;
+
+  if (enemyPosition !== null) {
+    // Phase 2: avoid the region containing the enemy
+    const ek = cellKey(enemyPosition.x, enemyPosition.y);
+    const enemyRegionIdx = regions.findIndex(r => r.has(ek));
+
+    if (enemyRegionIdx === -1) {
+      // Enemy is on a barrier — all regions are safe; pick the largest
+      regionToFill = regions.reduce((a, b) => a.size >= b.size ? a : b);
+    } else {
+      // Filter out the enemy's region; pick the largest remaining safe region
+      const safeRegions = regions.filter((_, i) => i !== enemyRegionIdx);
+      if (safeRegions.length === 0) {
+        checkLevelComplete();
+        return;
+      }
+      regionToFill = safeRegions.reduce((a, b) => a.size >= b.size ? a : b);
+    }
+  } else {
+    // Phase 1: fill the smaller region (authentic Styx behaviour)
+    regionToFill = regions.reduce((a, b) => a.size <= b.size ? a : b);
+  }
+
+  // 5. Claim the chosen region
+  regionToFill.forEach(k => claimedCells.add(k));
+
+  checkLevelComplete();
+}
+
+// ---------------------------------------------------------------------------
+// Check and dispatch level-complete event
+// ---------------------------------------------------------------------------
+function checkLevelComplete() {
+  const percentage = (claimedCells.size / TOTAL_PLAYFIELD_CELLS) * 100;
+  if (percentage >= 80) {
+    window.dispatchEvent(new CustomEvent('level-complete', {
+      detail: { percentage: percentage.toFixed(1) },
+    }));
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -124,7 +287,7 @@ window.addEventListener('keydown', function (e) {
     e.preventDefault();
   }
 
-  // SPACEBAR toggles draw mode on
+  // SPACEBAR activates draw mode
   if (e.code === 'Space') {
     if (!drawMode) {
       drawMode = true;
@@ -155,7 +318,7 @@ window.addEventListener('keydown', function (e) {
 
     // Check if moving back onto a safe edge while we have a line in progress
     if (currentLine.length > 0 && isOnSafeEdge(newPos.x, newPos.y)) {
-      // Line complete — add terminal point, trigger flood-fill, reset draw state
+      // Line complete — trigger flood-fill and reset draw state
       currentLine.push({ x: newPos.x, y: newPos.y });
       player.x = newPos.x;
       player.y = newPos.y;
@@ -164,7 +327,7 @@ window.addEventListener('keydown', function (e) {
       drawMode = false;
       floodFillClaim(completedLine, null);
     } else {
-      // Extend the line: record current player position before moving
+      // Extend the line: record current position before moving
       currentLine.push({ x: player.x, y: player.y });
       player.x = newPos.x;
       player.y = newPos.y;
@@ -184,13 +347,12 @@ window.addEventListener('keyup', function (e) {
   if (e.code === 'Space') {
     if (drawMode) {
       if (currentLine.length > 0) {
-        // SPACEBAR released mid-draw: erase unfinished line, return player to border
+        // SPACEBAR released mid-draw: erase line, snap player to nearest border
         currentLine = [];
-        // Snap player to nearest border edge
         const px = snapToGrid(player.x);
         const py = snapToGrid(player.y);
 
-        // Project to nearest border side
+        // Project to nearest border side by Manhattan distance
         const distLeft   = px - FIELD_LEFT;
         const distRight  = (FIELD_RIGHT - CELL) - px;
         const distTop    = py - FIELD_TOP;
@@ -199,12 +361,11 @@ window.addEventListener('keyup', function (e) {
 
         let bx = px;
         let by = py;
-        if (minDist === distLeft)   bx = FIELD_LEFT;
+        if      (minDist === distLeft)   bx = FIELD_LEFT;
         else if (minDist === distRight)  bx = FIELD_RIGHT - CELL;
         else if (minDist === distTop)    by = FIELD_TOP;
-        else                              by = FIELD_BOTTOM - CELL;
+        else                             by = FIELD_BOTTOM - CELL;
 
-        // Clamp to valid range after projection
         const clamped = clampToField(bx, by);
         player.x = clamped.x;
         player.y = clamped.y;
@@ -217,6 +378,19 @@ window.addEventListener('keyup', function (e) {
 // ---------------------------------------------------------------------------
 // Rendering
 // ---------------------------------------------------------------------------
+
+/**
+ * Draw all claimed territory cells as cyan 8×8 squares.
+ */
+function renderClaimedTerritory() {
+  ctx.fillStyle = CGA.CYAN;
+  claimedCells.forEach(k => {
+    const [cx, cy] = k.split(',').map(Number);
+    const px = FIELD_LEFT + cx * CELL;
+    const py = FIELD_TOP  + cy * CELL;
+    ctx.fillRect(px, py, CELL, CELL);
+  });
+}
 
 /**
  * Draw the in-progress Stix line as white filled squares (one per cell).
@@ -237,10 +411,23 @@ function renderPlayer() {
   ctx.fillRect(player.x, player.y, CELL, CELL);
 }
 
+/**
+ * Draw the territory percentage HUD (white monospace text, top of canvas).
+ */
+function renderHUD() {
+  const percentage = ((claimedCells.size / TOTAL_PLAYFIELD_CELLS) * 100).toFixed(1);
+  ctx.fillStyle = CGA.WHITE;
+  ctx.font = 'bold 13px monospace';
+  ctx.fillText(`Territory: ${percentage}%`, FIELD_LEFT + 4, FIELD_TOP - 2);
+}
+
 function render() {
   // Clear with black background
   ctx.fillStyle = CGA.BLACK;
   ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+
+  // Claimed territory (below the border line)
+  renderClaimedTerritory();
 
   // White playfield border rectangle
   ctx.strokeStyle = CGA.WHITE;
@@ -252,11 +439,14 @@ function render() {
     CANVAS_H - BORDER_INSET * 2
   );
 
-  // In-progress draw line (drawn before player so player is on top)
+  // In-progress draw line (beneath player)
   renderCurrentLine();
 
-  // Player
+  // Player (on top)
   renderPlayer();
+
+  // HUD overlay
+  renderHUD();
 }
 
 // ---------------------------------------------------------------------------

--- a/game/engine.js
+++ b/game/engine.js
@@ -55,6 +55,8 @@ const TOTAL_PLAYFIELD_CELLS = (FIELD_W_CELLS - 2) * (FIELD_H_CELLS - 2);
 let lives = 3;
 let level = 1;
 let gameOver = false;
+let levelTransition = false;  // true while level-complete overlay is showing
+let levelOverlayTimer = 0;    // seconds remaining for transition overlay
 
 /**
  * Invulnerability timer (seconds remaining after a death).
@@ -248,6 +250,8 @@ function resetGame() {
   level = 1;
   gameOver = false;
   invulnTimer = 0;
+  levelTransition = false;
+  levelOverlayTimer = 0;
   currentLine = [];
   drawMode = false;
   playerMovedThisFrame = false;
@@ -351,9 +355,35 @@ function floodFillClaim(borderLine, enemyPosition = null) {
 }
 
 // ---------------------------------------------------------------------------
+// Start next level: reset territory to border-only and respawn enemies
+// ---------------------------------------------------------------------------
+function startNextLevel() {
+  // Reset claimed territory: keep only the outer border cells
+  claimedCells.clear();
+  for (let cx = 0; cx < FIELD_W_CELLS; cx++) {
+    claimedCells.add(`${cx},0`);
+    claimedCells.add(`${cx},${FIELD_H_CELLS - 1}`);
+  }
+  for (let cy = 1; cy < FIELD_H_CELLS - 1; cy++) {
+    claimedCells.add(`0,${cy}`);
+    claimedCells.add(`${FIELD_W_CELLS - 1},${cy}`);
+  }
+  currentLine = [];
+  drawMode = false;
+  playerMovedThisFrame = false;
+  player.x = FIELD_LEFT;
+  player.y = FIELD_TOP;
+  resetFuse();
+  initStyxEnemies(level, claimedCells);
+  initWormEnemies(level, claimedCells);
+  levelTransition = false;
+}
+
+// ---------------------------------------------------------------------------
 // Check and dispatch level-complete event
 // ---------------------------------------------------------------------------
 function checkLevelComplete() {
+  if (levelTransition) return;  // already transitioning — don't fire again
   const percentage = (claimedCells.size / TOTAL_PLAYFIELD_CELLS) * 100;
   if (percentage >= 80) {
     window.dispatchEvent(new CustomEvent('level-complete', {
@@ -361,6 +391,16 @@ function checkLevelComplete() {
     }));
   }
 }
+
+// ---------------------------------------------------------------------------
+// Level-complete event listener
+// ---------------------------------------------------------------------------
+window.addEventListener('level-complete', function () {
+  level += 1;
+  levelTransition = true;
+  levelOverlayTimer = 1.5;
+});
+
 
 // ---------------------------------------------------------------------------
 // Input handling
@@ -543,6 +583,19 @@ function renderHUD() {
   }
 }
 
+function renderLevelTransition() {
+  ctx.fillStyle = 'rgba(0,0,0,0.75)';
+  ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+  ctx.fillStyle = CGA.CYAN;
+  ctx.font = 'bold 48px monospace';
+  ctx.textAlign = 'center';
+  ctx.fillText(`LEVEL ${level}`, CANVAS_W / 2, CANVAS_H / 2 - 20);
+  ctx.fillStyle = CGA.WHITE;
+  ctx.font = 'bold 16px monospace';
+  ctx.fillText('GET READY!', CANVAS_W / 2, CANVAS_H / 2 + 20);
+  ctx.textAlign = 'left';
+}
+
 function renderGameOver() {
   ctx.fillStyle = 'rgba(0,0,0,0.6)';
   ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
@@ -592,6 +645,9 @@ function render() {
   // HUD overlay
   renderHUD();
 
+  if (levelTransition) {
+    renderLevelTransition();
+  }
   if (gameOver) {
     renderGameOver();
   }
@@ -607,14 +663,22 @@ function gameLoop(timestamp) {
   lastTime = timestamp;
 
   if (!gameOver) {
-    // Tick down invulnerability timer
-    if (invulnTimer > 0) {
-      invulnTimer = Math.max(0, invulnTimer - dt);
-    }
+    // Handle level transition timer
+    if (levelTransition) {
+      levelOverlayTimer = Math.max(0, levelOverlayTimer - dt);
+      if (levelOverlayTimer <= 0) {
+        startNextLevel();
+      }
+    } else {
+      // Tick down invulnerability timer
+      if (invulnTimer > 0) {
+        invulnTimer = Math.max(0, invulnTimer - dt);
+      }
 
-    updateFuse(dt, drawMode, playerMovedThisFrame, currentLine, player, triggerDeath);
-    updateStyxEnemies(dt, claimedCells, currentLine, player, triggerDeath);
-    updateWormEnemies(dt, claimedCells, player, triggerDeath, level);
+      updateFuse(dt, drawMode, playerMovedThisFrame, currentLine, player, triggerDeath);
+      updateStyxEnemies(dt, claimedCells, currentLine, player, triggerDeath, level);
+      updateWormEnemies(dt, claimedCells, player, triggerDeath, level);
+    }
   }
 
   // Reset per-frame movement flag after fuse has read it

--- a/game/engine.js
+++ b/game/engine.js
@@ -1,1 +1,53 @@
-// TODO: implement — core game engine (canvas setup, game loop, player, territory)
+/**
+ * engine.js — Styx core game engine
+ * Canvas setup, 60fps game loop, CGA palette constants
+ */
+
+// CGA palette constants — all colour references must use these
+const CGA = {
+  BLACK:   '#000000',
+  CYAN:    '#00FFFF',
+  MAGENTA: '#FF00FF',
+  WHITE:   '#FFFFFF',
+};
+
+// ---------------------------------------------------------------------------
+// Canvas initialisation
+// ---------------------------------------------------------------------------
+const canvas = document.getElementById('styx-canvas');
+const ctx    = canvas.getContext('2d');
+
+const CANVAS_W = canvas.width;   // 800
+const CANVAS_H = canvas.height;  // 580
+
+// Playfield border inset (pixels from canvas edge)
+const BORDER_INSET = 8;
+
+// ---------------------------------------------------------------------------
+// Game loop
+// ---------------------------------------------------------------------------
+function render() {
+  // Clear with black background
+  ctx.fillStyle = CGA.BLACK;
+  ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+
+  // White playfield border rectangle
+  ctx.strokeStyle = CGA.WHITE;
+  ctx.lineWidth   = 2;
+  ctx.strokeRect(
+    BORDER_INSET,
+    BORDER_INSET,
+    CANVAS_W - BORDER_INSET * 2,
+    CANVAS_H - BORDER_INSET * 2
+  );
+}
+
+function gameLoop() {
+  render();
+  requestAnimationFrame(gameLoop);
+}
+
+// Kick off the loop once the page is ready
+window.addEventListener('load', function () {
+  requestAnimationFrame(gameLoop);
+});

--- a/game/engine.js
+++ b/game/engine.js
@@ -3,7 +3,8 @@
  * Canvas setup, 60fps game loop, CGA palette constants,
  * player movement (issue #3), draw mode & Stix line rendering (issue #4),
  * flood-fill territory claiming & HUD (issue #5),
- * Styx field enemy (issue #11).
+ * Styx field enemy (issue #11),
+ * Worm border patrol enemy (issue #12).
  */
 
 // CGA palette constants — all colour references must use these
@@ -471,6 +472,9 @@ function render() {
   // Styx enemies
   renderStyxEnemies(ctx);
 
+  // Worm enemies
+  renderWormEnemies(ctx);
+
   // Player (on top)
   renderPlayer();
 
@@ -493,6 +497,7 @@ function gameLoop(timestamp) {
 
   if (!gameOver) {
     updateStyxEnemies(dt, claimedCells, currentLine, player, triggerDeath);
+    updateWormEnemies(dt, claimedCells, player, triggerDeath, level);
   }
 
   render();
@@ -502,5 +507,7 @@ function gameLoop(timestamp) {
 // Kick off the loop once the page is ready
 window.addEventListener('load', function () {
   initStyxEnemies(level, claimedCells);
+  initWormEnemies(level, claimedCells);
   requestAnimationFrame(gameLoop);
 });
+

--- a/game/engine.js
+++ b/game/engine.js
@@ -57,6 +57,8 @@ let level = 1;
 let gameOver = false;
 let levelTransition = false;  // true while level-complete overlay is showing
 let levelOverlayTimer = 0;    // seconds remaining for transition overlay
+let titleScreen = true;        // true while title screen is showing
+let gameOverTimer = 0;         // countdown before returning to title screen
 // ---------------------------------------------------------------------------
 // Scoring & cycling multiplier (issue #21)
 // ---------------------------------------------------------------------------
@@ -449,6 +451,12 @@ window.addEventListener('keydown', function (e) {
     e.preventDefault();
   }
 
+  // Title screen: any key starts the game
+  if (titleScreen) {
+    titleScreen = false;
+    return;
+  }
+
   // Play-again: R key resets game when game over
   if (gameOver && e.code === 'KeyR') {
     resetGame();
@@ -550,8 +558,12 @@ window.addEventListener('keyup', function (e) {
   }
 });
 
-// Play-again: click canvas when game over
+// Play-again: click canvas when game over; also start from title screen
 canvas.addEventListener('click', function () {
+  if (titleScreen) {
+    titleScreen = false;
+    return;
+  }
   if (gameOver) {
     resetGame();
   }
@@ -633,33 +645,77 @@ function renderHUD() {
   }
 }
 
+
+function renderTitle() {
+  ctx.fillStyle = CGA.BLACK;
+  ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+
+  // Big STYX title
+  ctx.fillStyle = CGA.CYAN;
+  ctx.font = 'bold 96px monospace';
+  ctx.textAlign = 'center';
+  ctx.fillText('STYX', CANVAS_W / 2, CANVAS_H / 2 - 60);
+
+  // Subtitle
+  ctx.fillStyle = CGA.MAGENTA;
+  ctx.font = 'bold 18px monospace';
+  ctx.fillText('TERRITORY CONQUEST', CANVAS_W / 2, CANVAS_H / 2 - 15);
+
+  // Instructions
+  ctx.fillStyle = CGA.WHITE;
+  ctx.font = 'bold 14px monospace';
+  ctx.fillText('ARROW KEYS to move   SPACE to draw', CANVAS_W / 2, CANVAS_H / 2 + 30);
+  ctx.fillText('Claim 80% to advance   Avoid enemies!', CANVAS_W / 2, CANVAS_H / 2 + 52);
+
+  // Blinking prompt
+  const blink = Math.floor(Date.now() / 500) % 2 === 0;
+  if (blink) {
+    ctx.fillStyle = CGA.CYAN;
+    ctx.font = 'bold 16px monospace';
+    ctx.fillText('PRESS ANY KEY TO START', CANVAS_W / 2, CANVAS_H / 2 + 100);
+  }
+
+  ctx.textAlign = 'left';
+}
 function renderLevelTransition() {
   ctx.fillStyle = 'rgba(0,0,0,0.75)';
   ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
   ctx.fillStyle = CGA.CYAN;
-  ctx.font = 'bold 48px monospace';
+  ctx.font = 'bold 36px monospace';
   ctx.textAlign = 'center';
-  ctx.fillText(`LEVEL ${level}`, CANVAS_W / 2, CANVAS_H / 2 - 20);
+  ctx.fillText(`LEVEL ${level - 1} COMPLETE!`, CANVAS_W / 2, CANVAS_H / 2 - 30);
+  ctx.fillStyle = CGA.MAGENTA;
+  ctx.font = 'bold 48px monospace';
+  ctx.fillText(`LEVEL ${level}`, CANVAS_W / 2, CANVAS_H / 2 + 20);
   ctx.fillStyle = CGA.WHITE;
   ctx.font = 'bold 16px monospace';
-  ctx.fillText('GET READY!', CANVAS_W / 2, CANVAS_H / 2 + 20);
+  ctx.fillText('GET READY!', CANVAS_W / 2, CANVAS_H / 2 + 60);
   ctx.textAlign = 'left';
 }
 
 function renderGameOver() {
-  ctx.fillStyle = 'rgba(0,0,0,0.6)';
+  ctx.fillStyle = 'rgba(0,0,0,0.85)';
   ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
   ctx.fillStyle = CGA.MAGENTA;
-  ctx.font = 'bold 32px monospace';
+  ctx.font = 'bold 48px monospace';
   ctx.textAlign = 'center';
-  ctx.fillText('GAME OVER', CANVAS_W / 2, CANVAS_H / 2);
+  ctx.fillText('GAME OVER', CANVAS_W / 2, CANVAS_H / 2 - 40);
+  ctx.fillStyle = CGA.CYAN;
+  ctx.font = 'bold 20px monospace';
+  ctx.fillText(`FINAL SCORE: ${score}`, CANVAS_W / 2, CANVAS_H / 2 + 10);
   ctx.fillStyle = CGA.WHITE;
-  ctx.font = 'bold 16px monospace';
-  ctx.fillText('Press R or click to play again', CANVAS_W / 2, CANVAS_H / 2 + 36);
+  ctx.font = 'bold 13px monospace';
+  const secsLeft = Math.max(0, Math.ceil(3.0 - gameOverTimer));
+  ctx.fillText(`Returning to title in ${secsLeft}s...`, CANVAS_W / 2, CANVAS_H / 2 + 46);
   ctx.textAlign = 'left';
 }
 
 function render() {
+  if (titleScreen) {
+    renderTitle();
+    return;
+  }
+
   // Clear with black background
   ctx.fillStyle = CGA.BLACK;
   ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
@@ -711,6 +767,25 @@ let lastTime = null;
 function gameLoop(timestamp) {
   const dt = lastTime === null ? 0 : Math.min((timestamp - lastTime) / 1000, 0.1);
   lastTime = timestamp;
+
+  if (titleScreen) {
+    render();
+    requestAnimationFrame(gameLoop);
+    return;
+  }
+
+  if (gameOver) {
+    // Auto-return to title after 3 seconds
+    gameOverTimer += dt;
+    if (gameOverTimer >= 3.0) {
+      resetGame();
+      // resetGame sets titleScreen=true; fall through to normal render
+    } else {
+      render();
+      requestAnimationFrame(gameLoop);
+      return;
+    }
+  }
 
   if (!gameOver) {
     // Handle level transition timer

--- a/game/engine.js
+++ b/game/engine.js
@@ -28,13 +28,14 @@ const CANVAS_H = canvas.height;  // 580
 
 // Playfield border inset (pixels from canvas edge)
 const BORDER_INSET = 8;
+const HUD_HEIGHT = 28;
 
 // Grid cell size — player positions are always multiples of CELL
 const CELL = 8;
 
 // Playfield grid boundaries (pixel coords)
 const FIELD_LEFT   = BORDER_INSET;
-const FIELD_TOP    = BORDER_INSET;
+const FIELD_TOP    = BORDER_INSET + HUD_HEIGHT;
 const FIELD_RIGHT  = CANVAS_W - BORDER_INSET;
 const FIELD_BOTTOM = CANVAS_H - BORDER_INSET;
 
@@ -618,16 +619,16 @@ function renderHUD() {
   const percentage = ((claimedCells.size / TOTAL_PLAYFIELD_CELLS) * 100).toFixed(1);
   ctx.fillStyle = CGA.WHITE;
   ctx.font = 'bold 13px monospace';
-  ctx.fillText(`Territory: ${percentage}%`, FIELD_LEFT + 4, FIELD_TOP - 2);
-  ctx.fillText(`Level: ${level}`, FIELD_LEFT + 160, FIELD_TOP - 2);
-  ctx.fillText(`Score: ${score}`, FIELD_LEFT + 260, FIELD_TOP - 2);
+  ctx.fillText(`Territory: ${percentage}%`, FIELD_LEFT + 4, BORDER_INSET + 20);
+  ctx.fillText(`Level: ${level}`, FIELD_LEFT + 160, BORDER_INSET + 20);
+  ctx.fillText(`Score: ${score}`, FIELD_LEFT + 260, BORDER_INSET + 20);
 
   // Cycling multiplier block -- left of the lives icons
   const multVal   = MULTIPLIER_VALUES[multiplierIndex];
   const multColor = MULTIPLIER_COLORS[multiplierIndex];
   const blockSize = CELL + 2;
   const multX = FIELD_RIGHT - (lives * (CELL + 2)) - blockSize - 16;
-  const multY = BORDER_INSET - blockSize;
+  const multY = BORDER_INSET + 4;
   ctx.fillStyle = multColor;
   ctx.fillRect(multX, multY, blockSize, blockSize);
   ctx.fillStyle = CGA.BLACK;
@@ -638,7 +639,7 @@ function renderHUD() {
   const iconSize = CELL;
   const iconGap  = 2;
   const baseX    = FIELD_RIGHT - (lives * (iconSize + iconGap));
-  const baseY    = BORDER_INSET - iconSize - 1;
+  const baseY    = BORDER_INSET + 4;
   ctx.fillStyle = CGA.MAGENTA;
   for (let i = 0; i < lives; i++) {
     ctx.fillRect(baseX + i * (iconSize + iconGap), baseY, iconSize, iconSize);

--- a/game/engine.js
+++ b/game/engine.js
@@ -1,7 +1,7 @@
 /**
  * engine.js — Styx core game engine
  * Canvas setup, 60fps game loop, CGA palette constants,
- * player marker & 8-directional movement (issue #3).
+ * player movement (issue #3), draw mode & Stix line rendering (issue #4).
  */
 
 // CGA palette constants — all colour references must use these
@@ -50,6 +50,17 @@ const player = {
 /** Keys currently held (by e.code) */
 const keysHeld = new Set();
 
+/**
+ * Current in-progress Stix draw line.
+ * Array of {x, y} pixel positions tracing the path the player has drawn.
+ * Populated while SPACEBAR is held and player moves.
+ * Cleared when line completes (connects back to border) or SPACEBAR released.
+ */
+let currentLine = [];
+
+/** True when SPACEBAR is held and player is in draw mode. */
+let drawMode = false;
+
 // ---------------------------------------------------------------------------
 // Helper: snap a pixel value to the nearest CELL grid position
 // ---------------------------------------------------------------------------
@@ -69,7 +80,6 @@ function clampToField(px, py) {
 
 // ---------------------------------------------------------------------------
 // Helper: is (px, py) on the outer border perimeter?
-// Returns true when the position lies on the rectangular border edge.
 // ---------------------------------------------------------------------------
 function isOnOuterBorder(px, py) {
   const x = snapToGrid(px);
@@ -86,10 +96,21 @@ function isOnOuterBorder(px, py) {
 
 // ---------------------------------------------------------------------------
 // Helper: is (px, py) on a valid position for normal (non-draw) movement?
-// In issue #3 this is only the outer border; claimed-edge support is added in #5.
+// Extended in issue #5 to include claimed territory edges.
 // ---------------------------------------------------------------------------
 function isOnSafeEdge(px, py) {
   return isOnOuterBorder(px, py);
+}
+
+// ---------------------------------------------------------------------------
+// Stub: flood-fill claim — implemented in issue #5.
+// Called when the draw line connects back to a safe edge.
+//
+// @param {Array<{x:number, y:number}>} borderLine - Completed Stix line cells
+// @param {{x:number, y:number}|null} enemyPosition - See issue #5 for details
+// ---------------------------------------------------------------------------
+function floodFillClaim(borderLine, enemyPosition = null) { // eslint-disable-line no-unused-vars
+  // TODO: implement in issue #5 (flood-fill territory claiming)
 }
 
 // ---------------------------------------------------------------------------
@@ -103,7 +124,15 @@ window.addEventListener('keydown', function (e) {
     e.preventDefault();
   }
 
-  // Movement — only process arrow keys
+  // SPACEBAR toggles draw mode on
+  if (e.code === 'Space') {
+    if (!drawMode) {
+      drawMode = true;
+    }
+    return;
+  }
+
+  // Only process arrow keys for movement
   const isArrow = ['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(e.code);
   if (!isArrow) return;
 
@@ -117,20 +146,88 @@ window.addEventListener('keydown', function (e) {
 
   const newPos = clampToField(player.x + dx, player.y + dy);
 
-  // Normal mode: only allow movement along valid edges
-  if (isOnSafeEdge(newPos.x, newPos.y)) {
-    player.x = newPos.x;
-    player.y = newPos.y;
+  if (drawMode) {
+    // Draw mode: player can move into unclaimed interior space
+
+    // Cannot retrace or cross own current draw line
+    const onCurrentLine = currentLine.some(p => p.x === newPos.x && p.y === newPos.y);
+    if (onCurrentLine) return;
+
+    // Check if moving back onto a safe edge while we have a line in progress
+    if (currentLine.length > 0 && isOnSafeEdge(newPos.x, newPos.y)) {
+      // Line complete — add terminal point, trigger flood-fill, reset draw state
+      currentLine.push({ x: newPos.x, y: newPos.y });
+      player.x = newPos.x;
+      player.y = newPos.y;
+      const completedLine = currentLine.slice();
+      currentLine = [];
+      drawMode = false;
+      floodFillClaim(completedLine, null);
+    } else {
+      // Extend the line: record current player position before moving
+      currentLine.push({ x: player.x, y: player.y });
+      player.x = newPos.x;
+      player.y = newPos.y;
+    }
+  } else {
+    // Normal mode: only allow movement along safe edges
+    if (isOnSafeEdge(newPos.x, newPos.y)) {
+      player.x = newPos.x;
+      player.y = newPos.y;
+    }
   }
 });
 
 window.addEventListener('keyup', function (e) {
   keysHeld.delete(e.code);
+
+  if (e.code === 'Space') {
+    if (drawMode) {
+      if (currentLine.length > 0) {
+        // SPACEBAR released mid-draw: erase unfinished line, return player to border
+        currentLine = [];
+        // Snap player to nearest border edge
+        const px = snapToGrid(player.x);
+        const py = snapToGrid(player.y);
+
+        // Project to nearest border side
+        const distLeft   = px - FIELD_LEFT;
+        const distRight  = (FIELD_RIGHT - CELL) - px;
+        const distTop    = py - FIELD_TOP;
+        const distBottom = (FIELD_BOTTOM - CELL) - py;
+        const minDist = Math.min(distLeft, distRight, distTop, distBottom);
+
+        let bx = px;
+        let by = py;
+        if (minDist === distLeft)   bx = FIELD_LEFT;
+        else if (minDist === distRight)  bx = FIELD_RIGHT - CELL;
+        else if (minDist === distTop)    by = FIELD_TOP;
+        else                              by = FIELD_BOTTOM - CELL;
+
+        // Clamp to valid range after projection
+        const clamped = clampToField(bx, by);
+        player.x = clamped.x;
+        player.y = clamped.y;
+      }
+      drawMode = false;
+    }
+  }
 });
 
 // ---------------------------------------------------------------------------
 // Rendering
 // ---------------------------------------------------------------------------
+
+/**
+ * Draw the in-progress Stix line as white filled squares (one per cell).
+ */
+function renderCurrentLine() {
+  if (currentLine.length === 0) return;
+  ctx.fillStyle = CGA.WHITE;
+  for (const { x, y } of currentLine) {
+    ctx.fillRect(x, y, CELL, CELL);
+  }
+}
 
 /**
  * Draw the player marker — magenta 8×8 square.
@@ -154,6 +251,9 @@ function render() {
     CANVAS_W - BORDER_INSET * 2,
     CANVAS_H - BORDER_INSET * 2
   );
+
+  // In-progress draw line (drawn before player so player is on top)
+  renderCurrentLine();
 
   // Player
   renderPlayer();

--- a/game/engine.js
+++ b/game/engine.js
@@ -4,7 +4,8 @@
  * player movement (issue #3), draw mode & Stix line rendering (issue #4),
  * flood-fill territory claiming & HUD (issue #5),
  * Styx field enemy (issue #11),
- * Worm border patrol enemy (issue #12).
+ * Worm border patrol enemy (issue #12),
+ * Fuse hesitation penalty (issue #13).
  */
 
 // CGA palette constants — all colour references must use these
@@ -79,6 +80,9 @@ let currentLine = [];
 
 /** True when SPACEBAR is held and player is in draw mode. */
 let drawMode = false;
+
+/** Whether the player moved this frame (used by fuse logic). */
+let playerMovedThisFrame = false;
 
 /**
  * Claimed territory cells.
@@ -173,6 +177,8 @@ function triggerDeath() {
   lives -= 1;
   currentLine = [];
   drawMode = false;
+  playerMovedThisFrame = false;
+  resetFuse();
   player.x = FIELD_LEFT;
   player.y = FIELD_TOP;
   if (lives <= 0) {
@@ -343,12 +349,14 @@ window.addEventListener('keydown', function (e) {
       currentLine.push({ x: player.x, y: player.y });
       player.x = newPos.x;
       player.y = newPos.y;
+      playerMovedThisFrame = true;
     }
   } else {
     // Normal mode: only allow movement along safe edges
     if (isOnSafeEdge(newPos.x, newPos.y)) {
       player.x = newPos.x;
       player.y = newPos.y;
+      playerMovedThisFrame = true;
     }
   }
 });
@@ -469,6 +477,9 @@ function render() {
   // In-progress draw line (beneath player)
   renderCurrentLine();
 
+  // Fuse (on top of line, below player)
+  renderFuse(ctx, currentLine, player);
+
   // Styx enemies
   renderStyxEnemies(ctx);
 
@@ -496,9 +507,13 @@ function gameLoop(timestamp) {
   lastTime = timestamp;
 
   if (!gameOver) {
+    updateFuse(dt, drawMode, playerMovedThisFrame, currentLine, player, triggerDeath);
     updateStyxEnemies(dt, claimedCells, currentLine, player, triggerDeath);
     updateWormEnemies(dt, claimedCells, player, triggerDeath, level);
   }
+
+  // Reset per-frame movement flag after fuse has read it
+  playerMovedThisFrame = false;
 
   render();
   requestAnimationFrame(gameLoop);

--- a/game/engine.js
+++ b/game/engine.js
@@ -246,6 +246,7 @@ function triggerDeath() {
   resetFuse();
   multiplierIndex = 0;
   multiplierTimer = 0;
+  if (typeof sfxDeath === 'function') sfxDeath();
 
   if (lives <= 0) {
     gameOver = true;
@@ -372,6 +373,7 @@ function floodFillClaim(borderLine, enemyPosition = null) {
 
   // 5. Claim the chosen region
   regionToFill.forEach(k => claimedCells.add(k));
+  if (typeof sfxTerritoryClaim === 'function') sfxTerritoryClaim();
 
   // Award score: claimedArea% x baseScore x multiplier
   const claimedPct = (claimedCells.size / TOTAL_PLAYFIELD_CELLS) * 100;
@@ -415,6 +417,7 @@ function checkLevelComplete() {
   if (levelTransition) return;  // already transitioning — don't fire again
   const percentage = (claimedCells.size / TOTAL_PLAYFIELD_CELLS) * 100;
   if (percentage >= 80) {
+    if (typeof sfxLevelComplete === 'function') sfxLevelComplete();
     window.dispatchEvent(new CustomEvent('level-complete', {
       detail: { percentage: percentage.toFixed(1) },
     }));
@@ -454,6 +457,7 @@ window.addEventListener('keydown', function (e) {
   if (e.code === 'Space') {
     if (!drawMode) {
       drawMode = true;
+      if (typeof sfxDrawStart === 'function') sfxDrawStart();
     }
     return;
   }

--- a/game/engine.js
+++ b/game/engine.js
@@ -250,6 +250,7 @@ function triggerDeath() {
 
   if (lives <= 0) {
     gameOver = true;
+    score = 0;
     player.x = FIELD_LEFT;
     player.y = FIELD_TOP;
     window.dispatchEvent(new CustomEvent('game-over'));
@@ -282,6 +283,9 @@ function resetGame() {
   player.x = FIELD_LEFT;
   player.y = FIELD_TOP;
   resetFuse();
+  score = 0;
+  multiplierIndex = 0;
+  multiplierTimer = 0;
   initStyxEnemies(level, claimedCells);
   initWormEnemies(level, claimedCells);
 }

--- a/game/engine.js
+++ b/game/engine.js
@@ -1,6 +1,7 @@
 /**
  * engine.js — Styx core game engine
- * Canvas setup, 60fps game loop, CGA palette constants
+ * Canvas setup, 60fps game loop, CGA palette constants,
+ * player marker & 8-directional movement (issue #3).
  */
 
 // CGA palette constants — all colour references must use these
@@ -23,9 +24,122 @@ const CANVAS_H = canvas.height;  // 580
 // Playfield border inset (pixels from canvas edge)
 const BORDER_INSET = 8;
 
+// Grid cell size — player positions are always multiples of CELL
+const CELL = 8;
+
+// Playfield grid boundaries (pixel coords)
+const FIELD_LEFT   = BORDER_INSET;
+const FIELD_TOP    = BORDER_INSET;
+const FIELD_RIGHT  = CANVAS_W - BORDER_INSET;
+const FIELD_BOTTOM = CANVAS_H - BORDER_INSET;
+
 // ---------------------------------------------------------------------------
-// Game loop
+// Player state
 // ---------------------------------------------------------------------------
+
+/**
+ * Player state.
+ * x, y are pixel positions snapped to the CELL grid.
+ * Player starts at the top-left corner of the playfield border.
+ */
+const player = {
+  x: FIELD_LEFT,
+  y: FIELD_TOP,
+};
+
+/** Keys currently held (by e.code) */
+const keysHeld = new Set();
+
+// ---------------------------------------------------------------------------
+// Helper: snap a pixel value to the nearest CELL grid position
+// ---------------------------------------------------------------------------
+function snapToGrid(v) {
+  return Math.round(v / CELL) * CELL;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: clamp position to playfield grid boundaries
+// ---------------------------------------------------------------------------
+function clampToField(px, py) {
+  return {
+    x: Math.max(FIELD_LEFT, Math.min(FIELD_RIGHT - CELL, snapToGrid(px))),
+    y: Math.max(FIELD_TOP,  Math.min(FIELD_BOTTOM - CELL, snapToGrid(py))),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helper: is (px, py) on the outer border perimeter?
+// Returns true when the position lies on the rectangular border edge.
+// ---------------------------------------------------------------------------
+function isOnOuterBorder(px, py) {
+  const x = snapToGrid(px);
+  const y = snapToGrid(py);
+  const inHorizRange = x >= FIELD_LEFT && x <= FIELD_RIGHT - CELL;
+  const inVertRange  = y >= FIELD_TOP  && y <= FIELD_BOTTOM - CELL;
+  const onLeft   = x === FIELD_LEFT;
+  const onRight  = x === FIELD_RIGHT - CELL;
+  const onTop    = y === FIELD_TOP;
+  const onBottom = y === FIELD_BOTTOM - CELL;
+  return (onTop || onBottom) && inHorizRange ||
+         (onLeft || onRight) && inVertRange;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: is (px, py) on a valid position for normal (non-draw) movement?
+// In issue #3 this is only the outer border; claimed-edge support is added in #5.
+// ---------------------------------------------------------------------------
+function isOnSafeEdge(px, py) {
+  return isOnOuterBorder(px, py);
+}
+
+// ---------------------------------------------------------------------------
+// Input handling
+// ---------------------------------------------------------------------------
+window.addEventListener('keydown', function (e) {
+  keysHeld.add(e.code);
+
+  // Prevent page scroll from arrow keys and space
+  if (['ArrowUp','ArrowDown','ArrowLeft','ArrowRight',' '].includes(e.key)) {
+    e.preventDefault();
+  }
+
+  // Movement — only process arrow keys
+  const isArrow = ['ArrowUp','ArrowDown','ArrowLeft','ArrowRight'].includes(e.code);
+  if (!isArrow) return;
+
+  // Build delta from all currently held arrow keys (supports diagonals)
+  let dx = 0;
+  let dy = 0;
+  if (keysHeld.has('ArrowLeft'))  dx -= CELL;
+  if (keysHeld.has('ArrowRight')) dx += CELL;
+  if (keysHeld.has('ArrowUp'))    dy -= CELL;
+  if (keysHeld.has('ArrowDown'))  dy += CELL;
+
+  const newPos = clampToField(player.x + dx, player.y + dy);
+
+  // Normal mode: only allow movement along valid edges
+  if (isOnSafeEdge(newPos.x, newPos.y)) {
+    player.x = newPos.x;
+    player.y = newPos.y;
+  }
+});
+
+window.addEventListener('keyup', function (e) {
+  keysHeld.delete(e.code);
+});
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Draw the player marker — magenta 8×8 square.
+ */
+function renderPlayer() {
+  ctx.fillStyle = CGA.MAGENTA;
+  ctx.fillRect(player.x, player.y, CELL, CELL);
+}
+
 function render() {
   // Clear with black background
   ctx.fillStyle = CGA.BLACK;
@@ -40,8 +154,14 @@ function render() {
     CANVAS_W - BORDER_INSET * 2,
     CANVAS_H - BORDER_INSET * 2
   );
+
+  // Player
+  renderPlayer();
 }
 
+// ---------------------------------------------------------------------------
+// Game loop
+// ---------------------------------------------------------------------------
 function gameLoop() {
   render();
   requestAnimationFrame(gameLoop);

--- a/game/engine.js
+++ b/game/engine.js
@@ -2,7 +2,8 @@
  * engine.js — Styx core game engine
  * Canvas setup, 60fps game loop, CGA palette constants,
  * player movement (issue #3), draw mode & Stix line rendering (issue #4),
- * flood-fill territory claiming & HUD (issue #5).
+ * flood-fill territory claiming & HUD (issue #5),
+ * Styx field enemy (issue #11).
  */
 
 // CGA palette constants — all colour references must use these
@@ -43,6 +44,14 @@ const FIELD_H_CELLS = (FIELD_BOTTOM - FIELD_TOP) / CELL;
  * Subtract 2 on each axis to exclude the 1-cell-wide border row/column.
  */
 const TOTAL_PLAYFIELD_CELLS = (FIELD_W_CELLS - 2) * (FIELD_H_CELLS - 2);
+
+// ---------------------------------------------------------------------------
+// Game state
+// ---------------------------------------------------------------------------
+
+let lives = 3;
+let level = 1;
+let gameOver = false;
 
 // ---------------------------------------------------------------------------
 // Player state
@@ -153,27 +162,26 @@ function isOnSafeEdge(px, py) {
 }
 
 // ---------------------------------------------------------------------------
+// Death & reset
+// ---------------------------------------------------------------------------
+
+/**
+ * Handle player death: lose a life, reset draw state, snap player to border.
+ */
+function triggerDeath() {
+  lives -= 1;
+  currentLine = [];
+  drawMode = false;
+  player.x = FIELD_LEFT;
+  player.y = FIELD_TOP;
+  if (lives <= 0) {
+    gameOver = true;
+    window.dispatchEvent(new CustomEvent('game-over'));
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Flood-fill territory claiming
-//
-// @param {Array<{x:number, y:number}>} borderLine
-//   The newly completed Stix border line (pixel positions of drawn cells).
-//   These cells form the new border between claimed and unclaimed territory.
-//
-// @param {{x:number, y:number}|null} enemyPosition
-//   Optional enemy position in pixel coordinates.
-//
-//   PHASE 1 (no enemies): pass null — the function fills the SMALLER of the
-//   two regions enclosed by the new border line + existing claimed territory.
-//   Smaller-region fill is the authentic Styx mechanic (maximises risk/reward).
-//
-//   PHASE 2 (enemies): pass the enemy's current {x, y}.
-//   The function fills the region that does NOT contain the enemy, ensuring
-//   the enemy is never trapped in claimed territory. If the enemy is on a
-//   barrier cell (already claimed), all enclosed regions are safe to fill.
-//   If multiple safe regions exist, the largest is chosen to reward the player.
-//
-//   Example Phase 2 call:
-//     floodFillClaim(completedLine, { x: enemy.x, y: enemy.y });
 // ---------------------------------------------------------------------------
 function floodFillClaim(borderLine, enemyPosition = null) {
   // 1. Add borderLine pixels to claimedCells (they become the new wall)
@@ -182,7 +190,6 @@ function floodFillClaim(borderLine, enemyPosition = null) {
   });
 
   // 2. Build barrier set: outer border rows/cols + all claimed cells
-  //    Barrier = cannot be filled; flood-fill stays inside barriers.
   const barriers = new Set(claimedCells);
   for (let cx = 0; cx < FIELD_W_CELLS; cx++) {
     barriers.add(`${cx},0`);
@@ -287,6 +294,8 @@ window.addEventListener('keydown', function (e) {
     e.preventDefault();
   }
 
+  if (gameOver) return;
+
   // SPACEBAR activates draw mode
   if (e.code === 'Space') {
     if (!drawMode) {
@@ -325,7 +334,9 @@ window.addEventListener('keydown', function (e) {
       const completedLine = currentLine.slice();
       currentLine = [];
       drawMode = false;
-      floodFillClaim(completedLine, null);
+      // Pass Styx position so fill avoids trapping enemies
+      const enemyPos = styxEnemies.length > 0 ? { x: styxEnemies[0].x, y: styxEnemies[0].y } : null;
+      floodFillClaim(completedLine, enemyPos);
     } else {
       // Extend the line: record current position before moving
       currentLine.push({ x: player.x, y: player.y });
@@ -412,13 +423,28 @@ function renderPlayer() {
 }
 
 /**
- * Draw the territory percentage HUD (white monospace text, top of canvas).
+ * Draw the territory percentage and lives HUD.
  */
 function renderHUD() {
   const percentage = ((claimedCells.size / TOTAL_PLAYFIELD_CELLS) * 100).toFixed(1);
   ctx.fillStyle = CGA.WHITE;
   ctx.font = 'bold 13px monospace';
   ctx.fillText(`Territory: ${percentage}%`, FIELD_LEFT + 4, FIELD_TOP - 2);
+  ctx.fillText(`Lives: ${lives}`, FIELD_RIGHT - 80, FIELD_TOP - 2);
+  ctx.fillText(`Level: ${level}`, FIELD_LEFT + 160, FIELD_TOP - 2);
+}
+
+function renderGameOver() {
+  ctx.fillStyle = 'rgba(0,0,0,0.6)';
+  ctx.fillRect(0, 0, CANVAS_W, CANVAS_H);
+  ctx.fillStyle = CGA.MAGENTA;
+  ctx.font = 'bold 32px monospace';
+  ctx.textAlign = 'center';
+  ctx.fillText('GAME OVER', CANVAS_W / 2, CANVAS_H / 2);
+  ctx.fillStyle = CGA.WHITE;
+  ctx.font = 'bold 16px monospace';
+  ctx.fillText('Refresh to play again', CANVAS_W / 2, CANVAS_H / 2 + 36);
+  ctx.textAlign = 'left';
 }
 
 function render() {
@@ -442,22 +468,39 @@ function render() {
   // In-progress draw line (beneath player)
   renderCurrentLine();
 
+  // Styx enemies
+  renderStyxEnemies(ctx);
+
   // Player (on top)
   renderPlayer();
 
   // HUD overlay
   renderHUD();
+
+  if (gameOver) {
+    renderGameOver();
+  }
 }
 
 // ---------------------------------------------------------------------------
 // Game loop
 // ---------------------------------------------------------------------------
-function gameLoop() {
+let lastTime = null;
+
+function gameLoop(timestamp) {
+  const dt = lastTime === null ? 0 : Math.min((timestamp - lastTime) / 1000, 0.1);
+  lastTime = timestamp;
+
+  if (!gameOver) {
+    updateStyxEnemies(dt, claimedCells, currentLine, player, triggerDeath);
+  }
+
   render();
   requestAnimationFrame(gameLoop);
 }
 
 // Kick off the loop once the page is ready
 window.addEventListener('load', function () {
+  initStyxEnemies(level, claimedCells);
   requestAnimationFrame(gameLoop);
 });

--- a/game/index.html
+++ b/game/index.html
@@ -23,6 +23,7 @@
 </head>
 <body>
   <canvas id="styx-canvas" width="800" height="580"></canvas>
+  <script src="audio.js"></script>
   <script src="enemies.js"></script>
   <script src="engine.js"></script>
 </body>

--- a/game/index.html
+++ b/game/index.html
@@ -23,6 +23,7 @@
 </head>
 <body>
   <canvas id="styx-canvas" width="800" height="580"></canvas>
+  <script src="enemies.js"></script>
   <script src="engine.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Fixes #31 — HUD elements were rendering at negative y-coordinates and were invisible.

## Changes
- Added `HUD_HEIGHT = 28` constant in `engine.js`
- Changed `FIELD_TOP` to `BORDER_INSET + HUD_HEIGHT` (= 36) so the playfield starts below the HUD strip
- Updated `ENEMY_FIELD_TOP` in `enemies.js` to match (= 36)
- Fixed `renderHUD()` y-coordinates:
  - Territory/Level/Score text: `BORDER_INSET + 20` (y=28, baseline inside HUD strip)
  - Multiplier block top: `BORDER_INSET + 4` (y=12)
  - Lives icons top: `BORDER_INSET + 4` (y=12)

All HUD elements now render within the visible 28px strip at the top of the canvas (y=8 to y=36).

Closes #31