### PR TITLE
feat: player marker as 16px cross for visibility (closes #32)

### DIFF
--- a/game/engine.js
+++ b/game/engine.js
@@ -608,7 +608,13 @@ function renderPlayer() {
     if (!flash) return;
   }
   ctx.fillStyle = CGA.MAGENTA;
-  ctx.fillRect(player.x, player.y, CELL, CELL);
+  // Draw a cross/plus shape at 2×CELL size, centred on the grid cell (closes #32)
+  const cx = player.x + CELL / 2;
+  const cy = player.y + CELL / 2;
+  const half = CELL;      // half-span = 8px → total span = 16px
+  const arm  = 3;         // arm thickness
+  ctx.fillRect(cx - half, cy - arm, half * 2, arm * 2); // horizontal bar
+  ctx.fillRect(cx - arm, cy - half, arm * 2, half * 2); // vertical bar
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixes #32 — player marker was an 8×8px square, too small to see clearly.

## Changes
- `renderPlayer()` in `engine.js` now draws a cross/plus shape:
  - Horizontal bar: `cx ± CELL` wide, `±3px` tall
  - Vertical bar: `±3px` wide, `cy ± CELL` tall
  - Total visual span: 16×16px, still CGA magenta `#FF00FF`
- Player remains grid-snapped; the cross is centred on the grid cell
- Invulnerability flashing still works

Closes #32